### PR TITLE
Switch to dokku config-based configuration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ $ dokku help
 Obtain a Let's encrypt TLS certificate for app `myapp` (you can also run this command to renew the certificate):
 
 ```
-$ dokku config:set --no-restart myapp LE_EMAIL=your@email.tld
+$ dokku config:set --no-restart myapp DOKKU_LETSENCRYPT_EMAIL=your@email.tld
 -----> Setting config vars
-       LE_EMAIL: your@email.tld
+       DOKKU_LETSENCRYPT_EMAIL: your@email.tld
 $ dokku letsencrypt myapp
 =====> Let's Encrypt myapp...
 -----> Updating letsencrypt docker image...
@@ -73,11 +73,11 @@ Once the certificate is installed, you can use the `certs:*` built-in commands t
 ## Configuration
 `dokku-letsencrypt` uses the [Dokku environment variable manager](http://dokku.viewdocs.io/dokku/configuration-management/) for all configuration. The important environment variables are:
 
-Variable         | Default     | Description
------------------|-------------|-------------------------------------------------------------------------
-`LE_EMAIL`       | (none)      | **REQUIRED:** E-mail address to use for registering with Let's Encrypt.
-`LE_GRACEPERIOD` | 30 days     | Time in seconds left on a certificate before it should get renewed
-`LE_SERVER`      | default     | Which ACME server to use. Can be 'default', 'staging' or a URL
+Variable                        | Default     | Description
+--------------------------------|-------------|-------------------------------------------------------------------------
+`DOKKU_LETSENCRYPT_EMAIL`       | (none)      | **REQUIRED:** E-mail address to use for registering with Let's Encrypt.
+`DOKKU_LETSENCRYPT_GRACEPERIOD` | 30 days     | Time in seconds left on a certificate before it should get renewed
+`DOKKU_LETSENCRYPT_SERVER`      | default     | Which ACME server to use. Can be 'default', 'staging' or a URL
 
 You can set a setting using `dokku config:set --no-restart <myapp> SETTING_NAME=setting_value`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ dokku-letsencrypt is the official plugin for [dokku][dokku] that gives the abili
 $ sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
 ```
 
+### Upgrading from previous versions
+
+```sh
+# dokku 0.4+
+$ sudo dokku plugin:update dokku-letsencrypt
+```
+
+**IMPORTANT:** From version 0.7.0, the mechanism for storing configuration settings has changed and old settings will be ignored! Please be sure to re-configure `dokku-letsencrypt` (see the [configuration section below](#configuration))!
+
 ## Commands
 
 ```
@@ -22,14 +31,8 @@ $ dokku help
     letsencrypt <app>                       Enable or renew letsencrypt certificate for app
     letsencrypt:auto-renew                  Auto-renew all apps secured by letsencrypt if renewal is necessary
     letsencrypt:auto-renew <app>            Auto-renew app if renewal is necessary
-    letsencrypt:email <app>                 Get e-mail address used as letsencrypt contact
-    letsencrypt:email <app> <e-mail>        Set e-mail address used as letsencrypt contact
     letsencrypt:ls                          List letsencrypt-secured apps with certificate expiry
-    letsencrypt:renew-before <app>          Get renewal grace period for app
-    letsencrypt:renew-before <app> <time>   Set renewal grace period for app to <time> seconds
     letsencrypt:revoke <app>                Revoke letsencrypt certificate for app
-    letsencrypt:server <app>                Display selected letsencrypt server for app
-    letsencrypt:server <app> <server>       Select a letsencrypt server for app. Server can be 'default', 'staging' or a URL
 ```
 
 ## Usage
@@ -37,9 +40,9 @@ $ dokku help
 Obtain a Let's encrypt TLS certificate for app `myapp` (you can also run this command to renew the certificate):
 
 ```
-$ dokku letsencrypt:email myapp your@email.tld
-=====> Setting Let's Encrypt e-mail address for myapp to 'your@email.tld'
-
+$ dokku config:set --no-restart myapp LE_EMAIL=your@email.tld
+-----> Setting config vars
+       LE_EMAIL: your@email.tld
 $ dokku letsencrypt myapp
 =====> Let's Encrypt myapp...
 -----> Updating letsencrypt docker image...
@@ -66,6 +69,17 @@ Status: Image is up to date for m3adow/letsencrypt-simp_le:latest
 ```
 
 Once the certificate is installed, you can use the `certs:*` built-in commands to edit and query your certificate.
+
+## Configuration
+`dokku-letsencrypt` uses the [Dokku environment variable manager](http://dokku.viewdocs.io/dokku/configuration-management/) for all configuration. The important environment variables are:
+
+Variable         | Default     | Description
+-----------------|-------------|-------------------------------------------------------------------------
+`LE_EMAIL`       | (none)      | **REQUIRED:** E-mail address to use for registering with Let's Encrypt.
+`LE_GRACEPERIOD` | 30 days     | Time in seconds left on a certificate before it should get renewed
+`LE_SERVER`      | default     | Which ACME server to use. Can be 'default', 'staging' or a URL
+
+You can set a setting using `dokku config:set --no-restart <myapp> SETTING_NAME=setting_value`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.
 
 ## Design
 

--- a/commands
+++ b/commands
@@ -99,7 +99,7 @@ case "$1" in
 
     else
       expiry=$(letsencrypt_get_expirydate $APP)
-      grace_period=$(letsencrypt_get $APP LE_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT);
+      grace_period=$(letsencrypt_get $APP DOKKU_LETSENCRYPT_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT);
       time_to_expiry=$(( $expiry - $(date +%s) ))
       time_to_renewal=$(( $expiry - $grace_period - $(date +%s) ))
 

--- a/commands
+++ b/commands
@@ -22,7 +22,7 @@ if [[ $1 == letsencrypt || $1 == letsencrypt:* ]]; then
   fi
 
   # by default, renew 30 days before expiry
-  LETSENCRYPT_RENEWBEFORE_DEFAULT=$((30 * 24 * 60 * 60));
+  LETSENCRYPT_GRACEPERIOD_DEFAULT=$((30 * 24 * 60 * 60));
 fi
 
 case "$1" in
@@ -55,89 +55,6 @@ case "$1" in
     letsencrypt_acme_revoke || true
 
     dokku_log_verbose "done"
-    ;;
-
-  letsencrypt:server)
-    [[ -z $APP ]] && echo "Please specify an app to run the command on" && exit 1
-
-    letsencrypt_create_root
-
-    if [[ -z "$3" ]]; then
-      LETSENCRYPT_SERVER=$(letsencrypt_get server)
-
-      if [ -z "$LETSENCRYPT_SERVER" ]; then
-        dokku_log_verbose "Let's Encrypt server for $APP is default"
-      else
-        dokku_log_verbose "Let's Encrypt server for $APP is '$LETSENCRYPT_SERVER'"
-      fi
-
-    else
-
-      LETSENCRYPT_SERVER="$3"
-      if [ "$LETSENCRYPT_SERVER" == "default" ]; then
-        LETSENCRYPT_SERVER=""
-      elif [ "$LETSENCRYPT_SERVER" == "staging" ]; then
-        LETSENCRYPT_SERVER="https://acme-staging.api.letsencrypt.org/directory"
-      fi
-
-      dokku_log_info2 "Setting Let's Encrypt Server for $APP to '$LETSENCRYPT_SERVER'"
-      letsencrypt_set server $LETSENCRYPT_SERVER
-    fi
-
-    ;;
-
-  letsencrypt:email)
-    [[ -z $APP ]] && echo "Please specify an app to run the command on" && exit 1
-
-    letsencrypt_create_root
-
-    if [[ -z "$3" ]]; then
-      LETSENCRYPT_EMAIL=$(letsencrypt_get email)
-
-      if [ -z "$LETSENCRYPT_EMAIL" ]; then
-        dokku_log_verbose "Let's Encrypt e-mail for $APP is not set"
-        dokku_log_verbose "  to set, use dokku letsencrypt:email $APP <email>"
-      else
-        dokku_log_verbose "Let's Encrypt e-mail for $APP is '$LETSENCRYPT_EMAIL'"
-      fi
-
-    else
-
-      LETSENCRYPT_EMAIL="$3"
-      dokku_log_info2 "Setting Let's Encrypt e-mail address for $APP to '$LETSENCRYPT_EMAIL'"
-      letsencrypt_set email $LETSENCRYPT_EMAIL
-    fi
-
-    ;;
-
-  letsencrypt:renew-before)
-    [[ -z $APP ]] && echo "Please specify an app to run the command on" && exit 1
-
-    letsencrypt_create_root
-
-    if [[ -z "$3" ]]; then
-      LETSENCRYPT_RENEWBEFORE=$(letsencrypt_get renew_before $LETSENCRYPT_RENEWBEFORE_DEFAULT)
-      LETSENCRYPT_RENEWBEFORE_HUMAN=$(letsencrypt_format_timediff $LETSENCRYPT_RENEWBEFORE);
-      dokku_log_verbose "Will renew certificates for $APP $LETSENCRYPT_RENEWBEFORE_HUMAN before expiry"
-    else
-      LETSENCRYPT_RENEWBEFORE="$3"
-
-      RE_NUMBER='^[0-9]+$'
-      if [[ ! $LETSENCRYPT_RENEWBEFORE =~ $RE_NUMBER ]]; then
-        dokku_log_warn "Need a numeric input"
-        exit 1
-      fi
-
-      if [[ $LETSENCRYPT_RENEWBEFORE == 0 ]]; then
-        dokku_log_info2 "Restoring default renewal schedule for $APP"
-        letsencrypt_set renew_before ""
-      else
-        LETSENCRYPT_RENEWBEFORE_HUMAN=$(letsencrypt_format_timediff $LETSENCRYPT_RENEWBEFORE);
-        dokku_log_info2 "Setting time before let's encrypt certificate renewal to $LETSENCRYPT_RENEWBEFORE_HUMAN"
-        letsencrypt_set renew_before $LETSENCRYPT_RENEWBEFORE
-      fi
-
-    fi
     ;;
 
   letsencrypt:ls)
@@ -182,7 +99,7 @@ case "$1" in
 
     else
       expiry=$(letsencrypt_get_expirydate $APP)
-      grace_period=$(letsencrypt_get renew_before $LETSENCRYPT_RENEWBEFORE_DEFAULT);
+      grace_period=$(letsencrypt_get $APP LE_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT);
       time_to_expiry=$(( $expiry - $(date +%s) ))
       time_to_renewal=$(( $expiry - $grace_period - $(date +%s) ))
 
@@ -203,13 +120,7 @@ case "$1" in
     letsencrypt <app>, Enable or renew letsencrypt for app
     letsencrypt:auto-renew, Auto-renew all apps secured by letsencrypt if renewal is necessary
     letsencrypt:auto-renew <app>, Auto-renew app if renewal is necessary
-    letsencrypt:email <app>, Get e-mail address used as letsencrypt contact
-    letsencrypt:email <app> <e-mail>, Set e-mail address used as letsencrypt contact
-    letsencrypt:renew-before <app>, Get renewal grace period for app
-    letsencrypt:renew-before <app> <time>, Set renewal grace period for app to <time> seconds
     letsencrypt:revoke <app>, Revoke letsencrypt certificate for app
-    letsencrypt:server <app>, Get selected letsencrypt server for app
-    letsencrypt:server <app> <server>, Select a letsencrypt server for app (server can be 'default' 'staging' or a URL)
     letsencrypt:ls, List letsencrypt-secured apps with certificate expiry times
 EOF
 )

--- a/functions
+++ b/functions
@@ -173,7 +173,7 @@ letsencrypt_list_apps_and_expiry() {
     if [[ "$(letsencrypt_is_active $app)" == "$app" ]]; then
 
       expiry=$(letsencrypt_get_expirydate $app)
-      grace_period=$(letsencrypt_get $app LE_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT);
+      grace_period=$(letsencrypt_get $app DOKKU_LETSENCRYPT_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT);
       time_to_expiry=$(( $expiry - $(date +%s) ))
       time_to_renewal=$(( $expiry - $grace_period - $(date +%s) ))
       echo -e "$app\t$expiry\t$grace_period\t$time_to_expiry\t$time_to_renewal"
@@ -186,7 +186,7 @@ letsencrypt_configure_and_get_dir() {
   # this will be used to determine the folder name for the account key and certificates
 
   # get the selected ACME server
-  LETSENCRYPT_SERVER=$(letsencrypt_get $APP LE_SERVER)
+  LETSENCRYPT_SERVER=$(letsencrypt_get $APP DOKKU_LETSENCRYPT_SERVER)
   if [ -z "$LETSENCRYPT_SERVER" ] ||  [ "$LETSENCRYPT_SERVER" == "default" ]; then
     LETSENCRYPT_SERVER="https://acme-v01.api.letsencrypt.org/directory"
   elif [ "$LETSENCRYPT_SERVER" == "staging" ]; then
@@ -215,11 +215,11 @@ letsencrypt_configure_and_get_dir() {
 
 letsencrypt_check_email() {
   # check we have a valid e-mail address
-  LETSENCRYPT_EMAIL=$(letsencrypt_get $APP LE_EMAIL)
+  LETSENCRYPT_EMAIL=$(letsencrypt_get $APP DOKKU_LETSENCRYPT_EMAIL)
   if [ -z "$LETSENCRYPT_EMAIL" ]; then
     dokku_log_warn "ERROR: Cannot request a certificate without an e-mail address!"
     dokku_log_warn "  please provide your e-mail address using"
-    dokku_log_warn "  dokku config:set --no-restart $APP LE_EMAIL=<e-mail>"
+    dokku_log_warn "  dokku config:set --no-restart $APP DOKKU_LETSENCRYPT_EMAIL=<e-mail>"
     return 1
   fi
 }
@@ -232,7 +232,7 @@ letsencrypt_acme () {
   LETSENCRYPT_CONFIG_DIR=$(letsencrypt_configure_and_get_dir)
   LETSENCRYPT_CONFIG=$(cat $LETSENCRYPT_CONFIG_DIR/config)
 
-  LETSENCRYPT_GRACE=$(letsencrypt_get $APP LE_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT)
+  LETSENCRYPT_GRACE=$(letsencrypt_get $APP DOKKU_LETSENCRYPT_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT)
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy

--- a/functions
+++ b/functions
@@ -72,29 +72,23 @@ letsencrypt_create_root () {
 }
 
 letsencrypt_get() {
-  SETTINGNAME="$1"
-  DEFAULT="$2"
+  APP="$1"
+  SETTINGNAME="$2"
+  DEFAULT="$3"
 
-  if [ -z "$3" ]; then
-    SETTINGFILE="$LETSENCRYPT_ROOT/$SETTINGNAME"
-  else
-    SETTINGFILE="$DOKKU_ROOT/$3/letsencrypt/$SETTINGNAME"
-  fi
-
-  [ ! -f "$SETTINGFILE" ] && echo $DEFAULT || cat $SETTINGFILE
-
-}
-
-letsencrypt_set() {
-  SETTINGNAME="$1"
-  SETTINGFILE="$LETSENCRYPT_ROOT/$SETTINGNAME"
-  VALUE="$2"
+  # try getting setting from app config
+  VALUE=$(dokku config:get $APP $SETTINGNAME)
 
   if [ -z "$VALUE" ]; then
-    rm -f $SETTINGFILE
-  else
-    echo "$VALUE" > "$SETTINGFILE"
+    # try getting setting from global config
+    VALUE=$(dokku config:get --global $SETTINGNAME)
   fi
+
+  if [ -z "$VALUE" ]; then
+    VALUE="$DEFAULT"
+  fi
+
+  echo "$VALUE"
 }
 
 letsencrypt_format_timediff() {
@@ -179,7 +173,7 @@ letsencrypt_list_apps_and_expiry() {
     if [[ "$(letsencrypt_is_active $app)" == "$app" ]]; then
 
       expiry=$(letsencrypt_get_expirydate $app)
-      grace_period=$(letsencrypt_get renew_before $LETSENCRYPT_RENEWBEFORE_DEFAULT $app);
+      grace_period=$(letsencrypt_get $app LE_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT);
       time_to_expiry=$(( $expiry - $(date +%s) ))
       time_to_renewal=$(( $expiry - $grace_period - $(date +%s) ))
       echo -e "$app\t$expiry\t$grace_period\t$time_to_expiry\t$time_to_renewal"
@@ -192,9 +186,11 @@ letsencrypt_configure_and_get_dir() {
   # this will be used to determine the folder name for the account key and certificates
 
   # get the selected ACME server
-  LETSENCRYPT_SERVER=$(letsencrypt_get server)
-  if [ ! -z "$LETSENCRYPT_SERVER" ]; then
-    LETSENCRYPT_SERVER="--server $LETSENCRYPT_SERVER"
+  LETSENCRYPT_SERVER=$(letsencrypt_get $APP LE_SERVER)
+  if [ -z "$LETSENCRYPT_SERVER" ] ||  [ "$LETSENCRYPT_SERVER" == "default" ]; then
+    LETSENCRYPT_SERVER="https://acme-v01.api.letsencrypt.org/directory"
+  elif [ "$LETSENCRYPT_SERVER" == "staging" ]; then
+    LETSENCRYPT_SERVER="https://acme-staging.api.letsencrypt.org/directory"
   fi
 
   # construct domain arguments
@@ -205,7 +201,7 @@ letsencrypt_configure_and_get_dir() {
     DOMAIN_ARGS="$DOMAIN_ARGS -d $DOMAIN"
   done
 
-  LETSENCRYPT_CONFIG="$LETSENCRYPT_SERVER --email $LETSENCRYPT_EMAIL $DOMAIN_ARGS"
+  LETSENCRYPT_CONFIG="--server $LETSENCRYPT_SERVER --email $LETSENCRYPT_EMAIL $DOMAIN_ARGS"
   LETSENCRYPT_CONFIG_HASH=$(echo "$LETSENCRYPT_CONFIG" | sha1sum | awk '{print $1}')
   LETSENCRYPT_CONFIG_DIR="$LETSENCRYPT_ROOT/certs/$LETSENCRYPT_CONFIG_HASH"
   LETSENCRYPT_CONFIG_FILE="$LETSENCRYPT_CONFIG_DIR/config"
@@ -219,11 +215,11 @@ letsencrypt_configure_and_get_dir() {
 
 letsencrypt_check_email() {
   # check we have a valid e-mail address
-  LETSENCRYPT_EMAIL=$(letsencrypt_get email)
+  LETSENCRYPT_EMAIL=$(letsencrypt_get $APP LE_EMAIL)
   if [ -z "$LETSENCRYPT_EMAIL" ]; then
     dokku_log_warn "ERROR: Cannot request a certificate without an e-mail address!"
     dokku_log_warn "  please provide your e-mail address using"
-    dokku_log_warn "  dokku letsencrypt:email $APP <e-mail>"
+    dokku_log_warn "  dokku config:set --no-restart $APP LE_EMAIL=<e-mail>"
     return 1
   fi
 }
@@ -236,7 +232,7 @@ letsencrypt_acme () {
   LETSENCRYPT_CONFIG_DIR=$(letsencrypt_configure_and_get_dir)
   LETSENCRYPT_CONFIG=$(cat $LETSENCRYPT_CONFIG_DIR/config)
 
-  LETSENCRYPT_GRACE=$(letsencrypt_get renew_before $LETSENCRYPT_RENEWBEFORE_DEFAULT)
+  LETSENCRYPT_GRACE=$(letsencrypt_get $APP LE_GRACEPERIOD $LETSENCRYPT_GRACEPERIOD_DEFAULT)
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
 description = "Automated installation of let's encrypt TLS certificates"
-version = "0.6.1"
+version = "0.7.0"
 [plugin.config]


### PR DESCRIPTION
These commits switch from the old configuration method using e.g. `dokku letsencrypt:email` and files in the dokku `$APP_ROOT` (e.g. `$APP_ROOT/letsencrypt/email`) to the configuration management method discussed in #24.

Since changing configuration will break backwards compatibility, I'll be leaving this PR open to allow for some discussion.

I'd be grateful if some of you could try this out and report back to me if everything is working as intended or if there's some bugs that have snuck through. Thanks!