### PR TITLE
Added cron-job command

### DIFF
--- a/commands
+++ b/commands
@@ -14,6 +14,7 @@ case "$1" in
     letsencrypt <app>, Enable or renew letsencrypt for app
     letsencrypt:auto-renew, Auto-renew all apps secured by letsencrypt if renewal is necessary
     letsencrypt:auto-renew <app>, Auto-renew app if renewal is necessary
+    letsencrypt:cron-job [--add --remove], Add or remove a cron job that periodically calls auto-renew.
     letsencrypt:help, Display letsencrypt help
     letsencrypt:cleanup <app>, Remove stale certificate directories for app
     letsencrypt:revoke <app>, Revoke letsencrypt certificate for app
@@ -21,7 +22,7 @@ case "$1" in
 help_content
     }
 
-    if [[ $1 = "letsencrypt:help" ]]; then 
+    if [[ $1 = "letsencrypt:help" ]]; then
       echo -e 'Usage: dokku letsencrypt[:COMMAND]'
       echo ''
       echo 'Automatically retrieve and install Lets Encrypt certificates.'

--- a/cron-job
+++ b/cron-job
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+letsencrypt:auto-renew >> /var/log/dokku/letsencrypt.log

--- a/subcommands/cron-job
+++ b/subcommands/cron-job
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Setting "set -eo pipefail" breaks the crontab commands
+[[ $DOKKU_TRACE ]] && set -x
+
+CRON_CMD="$PLUGIN_AVAILABLE_PATH/letsencrypt/cron-job"
+CRON_JOB="@daily $CRON_CMD"
+
+letsencrypt_cron_job_add () {
+  crontab -l | grep -v "$CRON_CMD" ; echo "$CRON_JOB" | crontab -
+  echo "Added cron job to dokku's crontab."
+}
+
+letsencrypt_cron_job_remove () {
+  crontab -l | grep -v "$CRON_CMD" | crontab -
+  echo "Removed cron job from dokku's crontab."
+}
+
+letsencrypt_cron_job_cmd () {
+  #shellcheck disable=SC2034
+  declare desc="add or remove a cron job that periodically calls auto-renew"
+
+  if [[ $2 == "--add" ]]; then
+    letsencrypt_cron_job_add
+  elif [[ $2 == "--remove" ]]; then
+    letsencrypt_cron_job_remove
+  else
+    echo "Use --add or --remove to add or remove the cron job."
+  fi
+}
+
+letsencrypt_cron_job_cmd "$@"


### PR DESCRIPTION
Implements #57.

Dokku runs all commands as the dokku user, that way we would have to use sudo to link the cron entry. As on my system and others the dokku user has no sudo rights, the `dokku letsencrypt:cron-job` command just prints instructions for adding or removing the symlink.