### PR TITLE
Add current LE TOS hash to simp_le calls

### DIFF
--- a/functions
+++ b/functions
@@ -149,7 +149,7 @@ letsencrypt_configure_and_get_dir() {
     domain_args="$domain_args -d $domain"
   done
 
-  local config="--server $server --email $DOKKU_LETSENCRYPT_EMAIL --tos_sha256 6373439b9f29d67a5cd4d18cbc7f264809342dbf21cb2ba2fc7588df987a6221 $domain_args"
+  local config="--server $server --email $DOKKU_LETSENCRYPT_EMAIL --tos_sha256 cc88d8d9517f490191401e7b54e9ffd12a2b9082ec7a1d4cec6101f9f1647e7b $domain_args"
 
   local config_hash=$(echo "$config" | sha1sum | awk '{print $1}')
   local config_dir="$le_root/certs/$config_hash"; mkdir -p "$config_dir"


### PR DESCRIPTION
Workaround until kuba/simp_le is updated to ensure new account keys can be requested. See also 5a3b176a8fe856485781ba722be341918765f6ed.