### PR TITLE
Fix date command around DST switch

### DIFF
--- a/functions
+++ b/functions
@@ -76,7 +76,7 @@ letsencrypt_get_expirydate() {
   declare desc="print SSL certificate expiry date as UNIX timestamp"
   local app="$1"
 
-  date -d "$(openssl x509 -in "$DOKKU_ROOT/$app/tls/server.crt" -enddate -noout | sed -e "s/^notAfter=//")" "+%s"
+  date -u -d "$(openssl x509 -in "$DOKKU_ROOT/$app/tls/server.crt" -enddate -noout | sed -e "s/^notAfter=//")" "+%s"
 }
 
 letsencrypt_is_active() {


### PR DESCRIPTION
Lucky me, letsencrypt wants to expire certifactes right when DST switches.

```
$ dokku letsencrypt:ls
-----> App name           Certificate Expiry        Time before expiry        Time before renewal
date: invalid date ‘Mar 31 03:34:31 2019 GMT’
date: invalid date ‘Mar 31 03:33:58 2019 GMT’
date: invalid date ‘Mar 31 03:33:30 2019 GMT’
/var/lib/dokku/plugins/available/letsencrypt/functions: line 33: [: : integer expression expected
app-demo                  1970-01-31 03:00:00       17996d, 21h, 21m, 53s ago
/var/lib/dokku/plugins/available/letsencrypt/functions: line 33: [: : integer expression expected
app2-webapp               1970-01-31 03:00:00       17996d, 21h, 21m, 53s ago
/var/lib/dokku/plugins/available/letsencrypt/functions: line 33: [: : integer expression expected
app3-demo                 1970-01-31 03:00:00       17996d, 21h, 21m, 54s ago
```

Before:

```
export TZ=Europe/Riga
date -d 'Mar 31 03:34:31 2019 GMT' +%s
date: invalid date ‘Mar 31 03:34:31 2019 GMT’
```

After:

```
export TZ=Europe/Riga
date -u -d 'Mar 31 03:34:31 2019 GMT' +%s
1554003271
```
