### PR TITLE
Acme v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 dokku-letsencrypt is the official plugin for [dokku][dokku] that gives the ability to automatically retrieve and install TLS certificates from [letsencrypt.org](https://letsencrypt.org). During ACME validation, your app will stay available at any time.
 
-**Note:** Your app must already be deployed and accessible over the internet (i.e. in the browser) in order to add letsencrypt to your app. Your app just being created is not enough. If need the application to only be deployed via SSL, add a temporary certificate to your app prior to adding letsencrypt by running `dokku certs:generate <app> DOMAIN` to make your app accessible via SSL. This is mostly a optional step as the letsencrypt plugin will upgrade non-SSL apps when successful.
+**Note:** Your app must already be deployed and accessible over the internet (i.e. in the browser) in order to add letsencrypt to your app. Your app just being created is not enough. If you need the application to only be deployed via SSL, add a temporary certificate to your app prior to adding letsencrypt by running `dokku certs:generate <app> DOMAIN` to make your app accessible via SSL. This is mostly a optional step as the letsencrypt plugin will upgrade non-SSL apps when successful.
 
 **Note:** If you want to automatically renew the certificates, please use `dokku letsencrypt:cron-job --add` to add an auto-renewal cron-job to the crontab of the `dokku` user. This is supported starting from the plugin version 0.8.2 which only works with Dokku 0.5 or later.
 
@@ -104,7 +104,7 @@ You can [customize the nginx template](http://dokku.viewdocs.io/dokku/configurat
 `dokku-letsencrypt` gets around having to disable your web server using the following workflow:
 
   1. Temporarily add a reverse proxy for the `/.well-known/` path of your app to `https://127.0.0.1:$ACMEPORT`
-  2. Run [the simp_le Let's Encrypt client](https://github.com/kuba/simp_le) in a [Docker container](https://hub.docker.com/r/dokku/letsencrypt) binding to `$ACMEPORT` to complete the ACME challenge and retrieve the TLS certificates
+  2. Run [the simp_le Let's Encrypt client](https://github.com/zenhack/simp_le) in a [Docker container](https://hub.docker.com/r/dokku/letsencrypt) binding to `$ACMEPORT` to complete the ACME challenge and retrieve the TLS certificates
   3. Install the TLS certificates
   4. Remove the reverse proxy and reload nginx
 

--- a/functions
+++ b/functions
@@ -136,9 +136,9 @@ letsencrypt_configure_and_get_dir() {
   # get the selected ACME server
   local server=${DOKKU_LETSENCRYPT_SERVER:-default}
   if [ -z "$server" ] ||  [ "$server" == "default" ]; then
-    server="https://acme-v01.api.letsencrypt.org/directory"
+    server="https://acme-v02.api.letsencrypt.org/directory"
   elif [ "$server" == "staging" ]; then
-    server="https://acme-staging.api.letsencrypt.org/directory"
+    server="https://acme-staging-v02.api.letsencrypt.org/directory"
   fi
 
   # construct domain arguments

--- a/functions
+++ b/functions
@@ -149,8 +149,7 @@ letsencrypt_configure_and_get_dir() {
     domain_args="$domain_args -d $domain"
   done
 
-  local tos_sha=$(config_get --global DOKKU_LETSENCRYPT_TOS_SHA || echo cc88d8d9517f490191401e7b54e9ffd12a2b9082ec7a1d4cec6101f9f1647e7b);
-  local config="--server $server --email $DOKKU_LETSENCRYPT_EMAIL --tos_sha256 $tos_sha $domain_args"
+  local config="--server $server --email $DOKKU_LETSENCRYPT_EMAIL $domain_args"
 
   local config_hash=$(echo "$config" | sha1sum | awk '{print $1}')
   local config_dir="$le_root/certs/$config_hash"; mkdir -p "$config_dir"

--- a/subcommands/default
+++ b/subcommands/default
@@ -95,6 +95,7 @@ letsencrypt_acme () {
     -v "$config_dir:/certs" \
     dokku/letsencrypt:latest \
     -f account_key.json \
+    -f account_reg.json \
     -f fullchain.pem -f chain.pem -f cert.pem -f key.pem \
     --valid_min "${graceperiod}" \
     "${config[@]}"

--- a/subcommands/revoke
+++ b/subcommands/revoke
@@ -24,6 +24,7 @@ letsencrypt_acme_revoke () {
     -v "$config_dir:/certs" \
     dokku/letsencrypt:latest \
     -f account_key.json \
+    -f account_reg.json \
     -f fullchain.pem -f chain.pem -f cert.pem -f key.pem \
     --revoke \
     "${config[@]}"


### PR DESCRIPTION
This is work towards #183 and is related to dokku/docker-letsencrypt-simp_le#3

This updates the API endpoints to point to Acme v2 (both prod and staging) and updates the docker run commands to provide an additional required flag.