### PR TITLE
IP restricted vhost support

### DIFF
--- a/templates/letsencrypt.conf.sigil
+++ b/templates/letsencrypt.conf.sigil
@@ -1,4 +1,6 @@
 location /.well-known/acme-challenge/ {
+  # allow every ip address
+  allow all;
 
   # disable http-auth for /.well-known/acme-challenge
   auth_basic off;


### PR DESCRIPTION
This change allows to make acme challenges available on ip restricted vhosts.