### PR TITLE
Fix spelling

### DIFF
--- a/subcommands/auto-renew
+++ b/subcommands/auto-renew
@@ -52,7 +52,7 @@ letsencrypt_auto_renew_cmd() {
       dokku letsencrypt "$app"
     else
       days_left=$(letsencrypt_format_timediff $time_to_renewal)
-      dokku_log_verbose "$app still has $days_left days left before renewal"
+      dokku_log_verbose "$app still has $days_left left before renewal"
     fi
 
   fi


### PR DESCRIPTION
Currently, the `dokku letsencrypt:auto-renew` command’s output looks like this:

```
$ dokku letsencrypt:auto-renew
=====> Auto-renewing all apps...
       matomo still has 53m, 7s days left before renewal
       bazarr still has 1d, 8h, 32m, 27s days left before renewal
…
=====> Finished auto-renewal
```

After briefly testing, I think the output remains the same no matter the locale used. As you can see, the `$time_left` variable already contains all the time units, and the hard-coded string `days` just gets in the way.