### PR TITLE
Reuse account between multiples apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ dokku letsencrypt foo
 
 While playing around with this plugin, you might want to switch to the let's encrypt staging server by running `dokku config:set --no-restart myapp DOKKU_LETSENCRYPT_SERVER=staging` to enjoy much higher rate limits and switching back to the real server by running `dokku config:unset --no-restart myapp DOKKU_LETSENCRYPT_SERVER` once you are ready.
 
+## Dealing with rate limit on account creation
+
+There is a rate limit on the number of accounts created for one IP address and within an IPv6 /48 range.
+To avoid this, a new account is only created if you use a new value for DOKKU_LETSENCRYPT_EMAIL.
+
 ## Generating a Cert for multiple domains
 
 Your [default dokku app](http://dokku.viewdocs.io/dokku/configuration/domains/#default-site) is accessible under the root domain too. So if you have an application `00-default` that is running under `00-default.mydomain.com` it is accessible under `mydomain.com` too. Now if you apply letsencrypt for your `00-default` application, it is not accessible anymore on `mydomain.com`. You can add the root domain to your dokku domains by typing `dokku domains:add 00-default mydomain.com` and then `dokku letsencrypt 00-default` again.

--- a/subcommands/default
+++ b/subcommands/default
@@ -74,6 +74,8 @@ letsencrypt_acme () {
   declare desc="perform actual ACME validation procedure"
   local app="$1"
   local acme_port="$2"
+  local account_key="/home/dokku/account_key.json"
+  local account_reg="/home/dokku/account_reg.json"
 
   letsencrypt_create_root "$app"
 
@@ -87,6 +89,16 @@ letsencrypt_acme () {
   eval "$(config_export app "$app")"
 
   local graceperiod="${DOKKU_LETSENCRYPT_GRACEPERIOD:-$((60 * 60 * 24 * 30))}"
+
+  if [[ -f "$account_key" ]]; then
+    dokku_log_info2 "copy global account key file $account_key to app $config_dir"
+    cp $account_key "${config_dir}/account_key.json"
+  fi
+  if [[ -f "$account_reg" ]]; then
+    dokku_log_info2 "copy global account reg file $account_reg to app $config_dir"
+    cp $account_reg "${config_dir}/account_reg.json"
+  fi
+  dokku_log_info2 "starting docker run of ${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION} now for $app"
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy

--- a/subcommands/default
+++ b/subcommands/default
@@ -68,6 +68,18 @@ letsencrypt_link () {
   fi
 }
 
+letsencrypt_find_account () {
+  # dokku_log_info1 "searching for account for ${DOKKU_LETSENCRYPT_EMAIL}\n"
+  for f in `grep -l "DOKKU_LETSENCRYPT_EMAIL=\"${DOKKU_LETSENCRYPT_EMAIL}" /home/dokku/*/ENV`;  do 
+    local le_dir=${f/ENV/letsencrypt\/certs\/current/}
+    if [[ -f "${le_dir}account_key.json"  && -f "${le_dir}account_reg.json" ]]; then
+	echo $le_dir
+        return
+    fi
+  done
+  echo ""
+  return
+}
 
 letsencrypt_acme () {
   #shellcheck disable=SC2034
@@ -88,14 +100,22 @@ letsencrypt_acme () {
   eval "$(config_export global)"
   eval "$(config_export app "$app")"
 
+  local email="$DOKKU_LETSENCRYPT_EMAIL"
+  local account_source_dir="$(letsencrypt_find_account)"
+  if [[ $account_source_dir ]]; then 
+    dokku_log_info1 "account for ${DOKKU_LETSENCRYPT_EMAIL} found in ${account_source_dir}"
+    account_key="${account_source_dir}account_key.json"
+    account_reg="${account_source_dir}account_reg.json"
+  fi
+
   local graceperiod="${DOKKU_LETSENCRYPT_GRACEPERIOD:-$((60 * 60 * 24 * 30))}"
 
   if [[ -f "$account_key" ]]; then
-    dokku_log_info2 "copy global account key file $account_key to app $config_dir"
+    dokku_log_info2 "using copy of account key file $account_key"
     cp $account_key "${config_dir}/account_key.json"
   fi
   if [[ -f "$account_reg" ]]; then
-    dokku_log_info2 "copy global account reg file $account_reg to app $config_dir"
+    dokku_log_info2 "using copy of account reg file $account_reg"
     cp $account_reg "${config_dir}/account_reg.json"
   fi
   dokku_log_info2 "starting docker run of ${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION} now for $app"


### PR DESCRIPTION
Fixes #158

To avoid generating a new account for every app we must
supply the files `account_key.json` and `account_reg.json`
when the simp_le docker image is run.

If we don't supply them a new account and new files `account_key.json` and `account_reg.json` 
are created.

If you have already used `dokku letsencrypt` sucessfully once you can
copy the two files from /home/dokku/APPNAME/letsencrypt/certs/current/ to /home/dokku/
then each subsequent run of `dokku letsencrypt` will pick them up and copy
them over to the new apps configuration.  The account will be reused
and you will not run into the "too many accounts created" rate limit of letsencrypt