### PR TITLE
Add `DOKKU_LETSENCRYPT_ARGS` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Variable                        | Default     | Description
 `DOKKU_LETSENCRYPT_EMAIL`       | (none)      | **REQUIRED:** E-mail address to use for registering with Let's Encrypt.
 `DOKKU_LETSENCRYPT_GRACEPERIOD` | 30 days     | Time in seconds left on a certificate before it should get renewed
 `DOKKU_LETSENCRYPT_SERVER`      | default     | Which ACME server to use. Can be 'default', 'staging' or a URL
+`DOKKU_LETSENCRYPT_ARGS`        | (none)      | Extra arguments to pass via `docker run`. See the [lego CLI documentation](https://go-acme.github.io/lego/usage/cli/) for available options.
 
 You can set a setting using `dokku config:set --no-restart <myapp> SETTING_NAME=setting_value`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.
 

--- a/functions
+++ b/functions
@@ -178,7 +178,8 @@ letsencrypt_configure_and_get_dir() {
   eval "$(config_export global)"
   eval "$(config_export app "$app")"
   local graceperiod="${DOKKU_LETSENCRYPT_GRACEPERIOD:-$((60 * 60 * 24 * 30))}"
-  local config="--pem --http --http.port :$acme_port --accept-tos --cert.timeout $graceperiod --path /certs --server $server --email $DOKKU_LETSENCRYPT_EMAIL $domain_args"
+  local extra_args=$(config_get --global DOKKU_LETSENCRYPT_ARGS || config_get "$app" DOKKU_LETSENCRYPT_ARGS || '')
+  local config="--pem --http --http.port :$acme_port --accept-tos --cert.timeout $graceperiod --path /certs --server $server --email $DOKKU_LETSENCRYPT_EMAIL $extra_args $domain_args"
 
   local config_hash=$(echo "$config" | sha1sum | awk '{print $1}')
   local config_dir="$le_root/certs/$config_hash"


### PR DESCRIPTION
This allows for custom parameters to be passed to lego. We needed this to support older Sonos devices that require RSA (nod ECC) certificates by setting `"DOKKU_LETSENCRYPT_ARGS=--key rsa4096"`