### PR TITLE
Ignore random local port in config hash (fixes #240)

### DIFF
--- a/functions
+++ b/functions
@@ -179,14 +179,14 @@ letsencrypt_configure_and_get_dir() {
   eval "$(config_export app "$app")"
   local graceperiod="${DOKKU_LETSENCRYPT_GRACEPERIOD:-$((60 * 60 * 24 * 30))}"
   local extra_args="$(config_get --global DOKKU_LETSENCRYPT_ARGS || config_get "$app" DOKKU_LETSENCRYPT_ARGS || echo '')"
-  local config="--pem --http --http.port :$acme_port --accept-tos --cert.timeout $graceperiod --path /certs --server $server --email $DOKKU_LETSENCRYPT_EMAIL $extra_args $domain_args"
+  local config="--pem --http --accept-tos --cert.timeout $graceperiod --path /certs --server $server --email $DOKKU_LETSENCRYPT_EMAIL $extra_args $domain_args"
 
   local config_hash=$(echo "$config" | sha1sum | awk '{print $1}')
   local config_dir="$le_root/certs/$config_hash"
   mkdir -p "$config_dir"
 
   # store config settings
-  echo "$config" >"$config_dir/config"
+  echo "--http.port :$acme_port $config" >"$config_dir/config"
 
   echo "$config_dir"
 }


### PR DESCRIPTION
I haven't worked out how to test this yet, but I think this patch should fix issue #240, that this plugin registers a new account at the Let's Encrypt server every time it runs.