### PR TITLE
[WIP] Added DNS-01 challange support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ Dokku's default nginx template will automatically redirect HTTP requests to HTTP
 
 You can [customize the nginx template](http://dokku.viewdocs.io/dokku/configuration/nginx/) if you want different behaviour.
 
-## Design
+## Solving challanges with HTTP
+
+The default supported way of solving ACME challanges is HTTP.
+
+### Design
 
 `dokku-letsencrypt` gets around having to disable your web server using the following workflow:
 
@@ -118,6 +122,27 @@ You can [customize the nginx template](http://dokku.viewdocs.io/dokku/configurat
   4. Remove the reverse proxy and reload nginx
 
 For a more in-depth explanation, see [this blog post](https://blog.semicolonsoftware.de/securing-dokku-with-lets-encrypt-tls-certificates/)
+
+## Solving challanges with DNS-01
+
+To change the challange solver to dns you need to set the `DOKKU_LETSENCRYPT_CHALLANGE_MODE` variable to `dns`.
+```bash
+dokku config:set myapp DOKKU_LETSENCRYPT_CHALLANGE_MODE=dns
+```
+or you can set it globally:   
+```bash
+dokku config:set --global DOKKU_LETSENCRYPT_CHALLANGE_MODE=dns
+```
+Additionaly you will have to set the DNS provider you'd like to use. The full list of providers and their required environment variables can be found in the [lego documentation](https://go-acme.github.io/lego/dns/). For the following example we use `AWS Route53`:
+```bash
+dokku config:set DOKKU_LETSENCRYPT_DNS_PROVIDER=route53
+dokku config:set myapp DOKKU_LETSENCRYPT_LEGO_ENV_VARS="AWS_ACCESS_KEY_ID=AKIA5F0N000C0P000000;AWS_SECRET_ACCESS_KEY=xxx;AWS_HOSTED_ZONE_ID=Z01010100000000000000"
+```
+or you can set it globally: 
+```bash
+dokku config:set --global DOKKU_LETSENCRYPT_DNS_PROVIDER=route53
+dokku config:set --global DOKKU_LETSENCRYPT_LEGO_ENV_VARS="AWS_ACCESS_KEY_ID=AKIA5F0N000C0P000000;AWS_SECRET_ACCESS_KEY=xxx;AWS_HOSTED_ZONE_ID=Z01010100000000000000"
+```
 
 ## Dockerfile Deploys
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Variable                        | Default           | Description
 `DOKKU_LETSENCRYPT_GRACEPERIOD` | 5184000 (30 days) | Time in seconds left on a certificate before it should get renewed
 `DOKKU_LETSENCRYPT_SERVER`      | default           | Which ACME server to use. Can be 'default', 'staging' or a URL
 `DOKKU_LETSENCRYPT_ARGS`        | (none)            | Extra arguments to pass via `docker run`. See the [lego CLI documentation](https://go-acme.github.io/lego/usage/cli/) for available options.
+`DOKKU_LETSENCRYPT_CHALLANGE_MODE` | http           | The challange mode you'd like to use. Valid values are `http` and `dns`.
+`DOKKU_LETSENCRYPT_DNS_PROVIDER`   | (none)         | You must set this to a dns provider code from the [lego docs](https://go-acme.github.io/lego/dns/) if `DOKKU_LETSENCRYPT_CHALLANGE_MODE` is `dns`.
+`DOKKU_LETSENCRYPT_LEGO_ENV_VARS` | (none)          | Additional environment variables for lego CLI.
 
 You can set a setting using `dokku config:set --no-restart <myapp> SETTING_NAME=setting_value`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.
 

--- a/functions
+++ b/functions
@@ -143,12 +143,6 @@ letsencrypt_list_apps_and_expiry() {
   done
 }
 
-get_lego_env_vars() {
-  #shellcheck disable=SC2034
-  declare desc="assemble lego environment variables and create a config hash directory for them"
-  
-}
-
 letsencrypt_configure_and_get_dir() {
   #shellcheck disable=SC2034
   declare desc="assemble lego command line arguments and create a config hash directory for them"

--- a/functions
+++ b/functions
@@ -143,6 +143,12 @@ letsencrypt_list_apps_and_expiry() {
   done
 }
 
+get_lego_env_vars() {
+  #shellcheck disable=SC2034
+  declare desc="assemble lego environment variables and create a config hash directory for them"
+  
+}
+
 letsencrypt_configure_and_get_dir() {
   #shellcheck disable=SC2034
   declare desc="assemble lego command line arguments and create a config hash directory for them"
@@ -178,15 +184,47 @@ letsencrypt_configure_and_get_dir() {
   eval "$(config_export global)"
   eval "$(config_export app "$app")"
   local graceperiod="${DOKKU_LETSENCRYPT_GRACEPERIOD:-$((60 * 60 * 24 * 30))}"
+  local challange_mode="${DOKKU_LETSENCRYPT_CHALLANGE_MODE:-http}"
+  local dns_provider="${DOKKU_LETSENCRYPT_DNS_PROVIDER}"
+  if [[ "$challange_mode" = "dns" && -n "$dns_provider" ]]; then
+    challange_mode="$challange_mode $dns_provider"
+  fi
+
+  if [[ "$challange_mode" = "dns" && -z "$dns_provider" ]]; then
+    challange_mode="http"
+    echo "DNS Provider is not set for DNS challange mode. Falling back to http."
+  fi
   local extra_args="$(config_get --global DOKKU_LETSENCRYPT_ARGS || config_get "$app" DOKKU_LETSENCRYPT_ARGS || echo '')"
-  local config="--pem --http --accept-tos --cert.timeout $graceperiod --path /certs --server $server --email $DOKKU_LETSENCRYPT_EMAIL $extra_args $domain_args"
+
+  local config="--pem --$challange_mode --accept-tos --cert.timeout $graceperiod --path /certs --server $server --email $DOKKU_LETSENCRYPT_EMAIL $extra_args $domain_args"
 
   local config_hash=$(echo "$config" | sha1sum | awk '{print $1}')
   local config_dir="$le_root/certs/$config_hash"
   mkdir -p "$config_dir"
 
+  touch "$config_dir/env.list"
+
   # store config settings
-  echo "--http.port :$acme_port $config" >"$config_dir/config"
+  if [[ "$challange_mode" = "http" ]]; then
+    echo "--http.port :$acme_port $config" >"$config_dir/config"
+  else
+    echo "$config" >"$config_dir/config"
+
+    # store env var settings if DNS challange is used
+    declare -a env_var_array
+    local env_vars_raw="$(config_get --global DOKKU_LETSENCRYPT_LEGO_ENV_VARS || config_get "$app" DOKKU_LETSENCRYPT_LEGO_ENV_VARS || echo '')"
+    if [[ -n "$env_vars_raw" ]]; then
+      orig_ifs="$IFS"
+      IFS=';'
+      read -r -a env_var_array <<< "$env_vars_raw"
+      IFS="$orig_ifs"
+    fi
+
+    for key_value_pair in "${env_var_array[@]}"; do
+      echo "$key_value_pair" >> "$config_dir/env.list"
+    done
+  fi
+
 
   echo "$config_dir"
 }

--- a/subcommands/enable
+++ b/subcommands/enable
@@ -94,6 +94,7 @@ letsencrypt_acme() {
     --user $DOKKU_UID:$DOKKU_GID \
     -p "$acme_port:$acme_port" \
     -v "$config_dir:/certs" \
+    --env-file "$config_dir/env.list" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
     "${config[@]}" run | sed "s/^/       /"
 

--- a/subcommands/revoke
+++ b/subcommands/revoke
@@ -29,6 +29,7 @@ letsencrypt_acme_revoke() {
     --user $DOKKU_UID:$DOKKU_GID \
     -p "$acme_port:$acme_port" \
     -v "$config_dir:/certs" \
+    --env-file "$config_dir/env.list" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
     "${config[@]}" revoke | sed "s/^/       /"
 


### PR DESCRIPTION
I'm a very rookie with bash, so this PR can't be really called production ready.
For now it works by passing in the environment variables required for each supported DNS provider.

Known issues:   
- Credentials leaking into bash history, because you have to use `dokku config:set <app> DOKKU_LETSENCRYPT_LEGO_ENV_VARS="MY_SECRET=214;MY_OTHER_SECRET=sdfdsf"` to make the dns challange work.
- If you set `DOKKU_LETSENCRYPT_CHALLANGE_MODE` to `dns` but if you don't set `DOKKU_LETSENCRYPT_DNS_PROVIDER` the script won't notify you that you are doing something wrong.
- Untested wildcard support. (#189)

More info about env vars here; https://go-acme.github.io/lego/dns/      
Added new env vars for the plugin's configuration:     
- DOKKU_LETSENCRYPT_LEGO_ENV_VARS 
- DOKKU_LETSENCRYPT_DNS_PROVIDER
- DOKKU_LETSENCRYPT_CHALLANGE_MODE


Variable                        | Default           | Description
--------------------------------|-------------------|----------------------
`DOKKU_LETSENCRYPT_CHALLANGE_MODE` | http           | The challange mode you'd like to use. Valid values are `http` and `dns`.
`DOKKU_LETSENCRYPT_DNS_PROVIDER`   | (none)         | You must set this to a dns provider code from the [lego docs](https://go-acme.github.io/lego/dns/) if `DOKKU_LETSENCRYPT_CHALLANGE_MODE` is `dns`.
`DOKKU_LETSENCRYPT_LEGO_ENV_VARS` | (none)          | Additional environment variables for lego CLI.

I'm opening this here in hope that the community will pitch in some ideas for solving the issues described above. 😸 