### PR TITLE
fix: respect a mapped dokku root when running dokku in a container

### DIFF
--- a/functions
+++ b/functions
@@ -188,7 +188,8 @@ letsencrypt_configure_and_get_dir() {
   # store config settings
   echo "--http.port :$acme_port $config" >"$config_dir/config"
 
-  echo "$config_dir"
+  # re-implement entire path to respect mapped DOKKU_ROOT when running in a container
+  echo "$DOKKU_HOST_ROOT/$app/letsencrypt/certs/$config_hash"
 }
 
 letsencrypt_check_email() {


### PR DESCRIPTION
Closes #235