### PR TITLE
fix: use container-local config dir path when reading arguments

### DIFF
--- a/functions
+++ b/functions
@@ -188,8 +188,9 @@ letsencrypt_configure_and_get_dir() {
   # store config settings
   echo "--http.port :$acme_port $config" >"$config_dir/config"
 
-  # re-implement entire path to respect mapped DOKKU_ROOT when running in a container
-  echo "$DOKKU_HOST_ROOT/$app/letsencrypt/certs/$config_hash"
+  # send both host and container path
+  # to respect mapped DOKKU_ROOT when running in a container
+  echo "$DOKKU_HOST_ROOT/$app/letsencrypt/certs/$config_hash:$config_dir"
 }
 
 letsencrypt_get_email() {

--- a/subcommands/enable
+++ b/subcommands/enable
@@ -84,8 +84,10 @@ letsencrypt_acme() {
   dokku_log_info1 "Getting letsencrypt certificate for ${app}..."
 
   # read arguments from appropriate config file into the config array
-  config_dir="$(letsencrypt_configure_and_get_dir "$app" "$acme_port")"
-  read -r -a config <"$config_dir/config"
+  config_dirs="$(letsencrypt_configure_and_get_dir "$app" "$acme_port")"
+  host_config_dir="$(echo "$config_dirs" | cut -d: -f1)"
+  container_config_dir="$(echo "$config_dirs" | cut -d: -f2)"
+  read -r -a config <"$container_config_dir/config"
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
@@ -95,7 +97,7 @@ letsencrypt_acme() {
   docker run --rm \
     --user $DOKKU_UID:$DOKKU_GID \
     -p "$acme_port:$acme_port" \
-    -v "$config_dir:/certs" \
+    -v "$host_config_dir:/certs" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
     "${config[@]}" run | sed "s/^/       /"
 

--- a/subcommands/revoke
+++ b/subcommands/revoke
@@ -17,8 +17,10 @@ letsencrypt_acme_revoke() {
   local acme_port=$(get_available_port)
 
   # read arguments from appropriate config file into the config array
-  local config_dir="$(letsencrypt_configure_and_get_dir "$app" "$acme_port")"
-  read -r -a config <"$config_dir/config"
+  config_dirs="$(letsencrypt_configure_and_get_dir "$app" "$acme_port")"
+  host_config_dir="$(echo "$config_dirs" | cut -d: -f1)"
+  container_config_dir="$(echo "$config_dirs" | cut -d: -f2)"
+  read -r -a config <"$container_config_dir/config"
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
@@ -28,7 +30,7 @@ letsencrypt_acme_revoke() {
   docker run --rm \
     --user $DOKKU_UID:$DOKKU_GID \
     -p "$acme_port:$acme_port" \
-    -v "$config_dir:/certs" \
+    -v "$host_config_dir:/certs" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
     "${config[@]}" revoke | sed "s/^/       /"
 


### PR DESCRIPTION
Fixes #235 

The `letsencrypt_configure_and_get_dir` function now returns both the host and container path to the `config_dir` separated by a colon (`:`).

In subcommands, functions calling `letsencrypt_configure_and_get_dir` now parse the returned paths to split by colon and populate two variables: `host_config_dir` and `container_config_dir`.