### PR TITLE
Remove letsencrypt:enable from post-domains-update

### DIFF
--- a/post-domains-update
+++ b/post-domains-update
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 

--- a/post-domains-update
+++ b/post-domains-update
@@ -8,7 +8,7 @@ trigger-letsencrypt-post-domains-update() {
   declare APP="$1" ACTION="$2"
 
   if [[ "$ACTION" == "add" ]] || [[ "$ACTION" == "set" ]]; then
-    dokku letsencrypt:enable "$APP"
+    dokku_log_warn "Please run dokku letsencrypt:enable to add https support to the new domain"
   fi
 }
 


### PR DESCRIPTION
Due to order of operations, we add the cert before the router knows the cert is available. Disabling this for now adding new domains to apps.

Refs #264
Closes #264