### PR TITLE
add newline at the end of crontab

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -310,7 +310,7 @@ fn-letsencrypt-cron-job-add() {
   else
     crons="$(crontab -l || true)"
     crons="$(grep -v -F "$LETSENCRYPT_CRON_CMD" <<<"$crons")"
-    printf "%s\n%s" "$crons" "$LETSENCRYPT_CRON_JOB" | crontab -
+    printf "%s\n%s\n" "$crons" "$LETSENCRYPT_CRON_JOB" | crontab -
   fi
 
   dokku_log_info1 "Added cron job to dokku's crontab."


### PR DESCRIPTION
Fixes an error I’ve got:

> root@lebkowski:~# dokku letsencrypt:cron-job --add
> new crontab file is missing newline before EOF, can't install.