### PR TITLE
support wildcard domains

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -528,8 +528,10 @@ fn-letsencrypt-is-active() {
   fi
 
   local le_sha1="not_found"
-  if [[ -f "$DOKKU_ROOT/$APP/letsencrypt/certs/current/certificates/$domain.pem" ]]; then
-    le_sha1=$( (cat "$DOKKU_ROOT/$APP/letsencrypt/certs/current/certificates/$domain.crt" 2>/dev/null) | sha1sum || echo "not_found")
+  local fileSafeDomain
+  fileSafeDomain="${domain/\*/_}" # wildcards are using *.example.com which have certificates named _.example.com
+  if [[ -f "$DOKKU_ROOT/$APP/letsencrypt/certs/current/certificates/$fileSafeDomain.pem" ]]; then
+    le_sha1=$( (cat "$DOKKU_ROOT/$APP/letsencrypt/certs/current/certificates/$fileSafeDomain.crt" 2>/dev/null) | sha1sum || echo "not_found")
   elif [[ -f "$DOKKU_ROOT/$APP/letsencrypt/certs/current/fullchain.pem" ]]; then
     le_sha1=$( (cat "$DOKKU_ROOT/$APP/letsencrypt/certs/current/fullchain.pem" 2>/dev/null) | sha1sum || echo "not_found")
   fi
@@ -611,8 +613,10 @@ fn-letsencrypt-symlink-certs() {
   # install the let's encrypt certificate for the app
   unset DOKKU_APP_NAME
   domain="$(get_app_domains "$APP" | xargs | awk '{print $1}')"
-  dokku certs:add "$APP" "$config_dir/certificates/$domain.pem" "$config_dir/certificates/$domain.key"
+  local fileSafeDomain
+  fileSafeDomain="${domain/\*/_}" # wildcards are using *.example.com which have certificates named _.example.com
+  dokku certs:add "$APP" "$config_dir/certificates/$fileSafeDomain.pem" "$config_dir/certificates/$fileSafeDomain.key"
   rm -f "$app_root/tls/server.letsencrypt.crt" "$app_root/tls/server.crt"
-  cp "$config_dir/certificates/$domain.crt" "$app_root/tls/server.letsencrypt.crt"
-  cp "$config_dir/certificates/$domain.crt" "$app_root/tls/server.crt"
+  cp "$config_dir/certificates/$fileSafeDomain.crt" "$app_root/tls/server.letsencrypt.crt"
+  cp "$config_dir/certificates/$fileSafeDomain.crt" "$app_root/tls/server.crt"
 }


### PR DESCRIPTION
[In Lego](https://go-acme.github.io/lego/usage/cli/obtain-a-certificate/), wildcard domains are creating files named _.example.com if the file domain is a wildcard domain like *.example.com

fixes https://github.com/dokku/dokku-letsencrypt/issues/298