### PR TITLE
fix: silence openssl warning in letsencrypt:report

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -442,7 +442,7 @@ fn-letsencrypt-expiration() {
 
   if [[ -f "$DOKKU_ROOT/$APP/tls/server.letsencrypt.crt" ]]; then
     date -u -d "$(openssl x509 -in "$DOKKU_ROOT/$APP/tls/server.letsencrypt.crt" -enddate -noout | sed -e "s/^notAfter=//")" "+%s"
-  else
+  elif [[ -f "$DOKKU_ROOT/$APP/tls/server.crt" ]]; then
     date -u -d "$(openssl x509 -in "$DOKKU_ROOT/$APP/tls/server.crt" -enddate -noout | sed -e "s/^notAfter=//")" "+%s"
   fi
 }


### PR DESCRIPTION
When no certificate exists for an app, `fn-letsencrypt-expiration` previously fell through to running `openssl x509` against `server.crt` without verifying the file exists, producing stderr noise about a missing scheme and an unloadable certificate. The expiration value is now left empty when neither the lego-managed nor user-supplied certificate is present, matching how other report fields render missing values.