### PR TITLE
feat: support --format json and --global on letsencrypt:report

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -12,3 +12,5 @@ disable=SC2154
 disable=SC2155
 # SC2231: unquoted glob in for-loops on known-safe paths
 disable=SC2231
+# SC2178: bash nameref via `local -n` is intentionally an array reference
+disable=SC2178

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ dokku letsencrypt:help
     letsencrypt:disable <app>               Disable letsencrypt for an app
     letsencrypt:enable <app>                Enable or renew letsencrypt for an app
     letsencrypt:list                        List letsencrypt-secured apps with certificate expiry
+    letsencrypt:report [<app>|--global]     Display a letsencrypt report for one or more apps
     letsencrypt:revoke <app>                Revoke letsencrypt certificate for app
 ```
 
@@ -116,6 +117,37 @@ Variable             | Default           | Description
 You can set a setting using `dokku letsencrypt:set $APP $SETTING_NAME $SETTING_VALUE`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.
 
 > Note: See "DNS-01 Challenge" for more information on configuration a dns-provider for DNS-01 based challenges and wildcard support.
+
+## Reports
+
+The `letsencrypt:report` command exposes app-level and global plugin properties for consumption by external tooling. Without arguments, it prints a human-readable report for every app:
+
+```shell
+dokku letsencrypt:report
+dokku letsencrypt:report myapp
+```
+
+Pass `--global` to limit output to the global properties only:
+
+```shell
+dokku letsencrypt:report --global
+```
+
+Pass `--format json` to emit a JSON object instead of the default stdout layout. The flag works with app, global, and "all apps" invocations:
+
+```shell
+dokku letsencrypt:report myapp --format json
+dokku letsencrypt:report --global --format json
+dokku letsencrypt:report --format json
+```
+
+Specifying a single property flag (such as `--letsencrypt-email`) still prints just that value:
+
+```shell
+dokku letsencrypt:report myapp --letsencrypt-email
+```
+
+Combining `--format json` with a single property flag is rejected.
 
 ## Redirecting from HTTP to HTTPS
 

--- a/command-functions
+++ b/command-functions
@@ -198,7 +198,10 @@ cmd-letsencrypt-report() {
   declare desc="displays a letsencrypt report for one or more apps"
   declare cmd="letsencrypt:report"
   [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1" INFO_FLAG="$2"
+  fn-letsencrypt-report-parse-args "$@"
+  set -- "${REPORT_ARGS[@]}"
+
+  declare APP="${1:-}" INFO_FLAG="${2:-}"
   local INSTALLED_APPS
   INSTALLED_APPS=$(dokku_apps)
 
@@ -207,25 +210,33 @@ cmd-letsencrypt-report() {
     APP=""
   fi
 
+  if [[ "$REPORT_IS_GLOBAL" == "true" ]]; then
+    APP="--global"
+  fi
+
   if [[ -z "$APP" ]] && [[ -z "$INFO_FLAG" ]]; then
     INFO_FLAG="true"
   fi
 
-  if [[ -z "$APP" ]]; then
+  if [[ "$APP" == "--global" ]]; then
+    cmd-letsencrypt-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
+  elif [[ -z "$APP" ]]; then
     for app in $INSTALLED_APPS; do
-      cmd-letsencrypt-report-single "$app" "$INFO_FLAG" | tee || true
+      cmd-letsencrypt-report-single "$app" "$INFO_FLAG" "$REPORT_FORMAT" | tee || true
     done
   else
-    cmd-letsencrypt-report-single "$APP" "$INFO_FLAG"
+    cmd-letsencrypt-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
   fi
 }
 
 cmd-letsencrypt-report-single() {
-  declare APP="$1" INFO_FLAG="$2"
+  declare APP="$1" INFO_FLAG="$2" FORMAT="${3:-stdout}"
   if [[ "$INFO_FLAG" == "true" ]]; then
     INFO_FLAG=""
   fi
-  verify_app_name "$APP"
+  if [[ "$APP" != "--global" ]]; then
+    verify_app_name "$APP"
+  fi
   local flag_map=(
     "--letsencrypt-active: $(fn-letsencrypt-is-active "$APP")"
     "--letsencrypt-autorenew: $(fn-letsencrypt-is-autorenew-enabled "$APP")"
@@ -247,8 +258,23 @@ cmd-letsencrypt-report-single() {
     "--letsencrypt-server: $(fn-letsencrypt-server "$APP")"
   )
 
+  if [[ "$APP" == "--global" ]]; then
+    fn-letsencrypt-report-filter-global flag_map
+  fi
+
+  fn-letsencrypt-report-validate-format "$FORMAT" "$INFO_FLAG"
+
+  if [[ "$FORMAT" == "json" ]]; then
+    fn-letsencrypt-report-emit-json flag_map
+    return
+  fi
+
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2_quiet "${APP} letsencrypt information"
+    if [[ "$APP" == "--global" ]]; then
+      dokku_log_info2_quiet "global letsencrypt information"
+    else
+      dokku_log_info2_quiet "${APP} letsencrypt information"
+    fi
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-30s %-25s" "${key^}" "${flag#*: }")"

--- a/help-functions
+++ b/help-functions
@@ -35,6 +35,7 @@ fn-help-content() {
     letsencrypt:enable <app>, Enable or renew letsencrypt for an app
     letsencrypt:help, Display letsencrypt help
     letsencrypt:list, List letsencrypt-secured apps with certificate expiry times
+    letsencrypt:report [<app>|--global] [<flag>] [--format json], Display a letsencrypt report for one or more apps
     letsencrypt:revoke <app>, Revoke letsencrypt certificate for app
     letsencrypt:set <app> <property> (<value>), Set or clear a letsencrypt property for an app
 help_content

--- a/internal-functions
+++ b/internal-functions
@@ -637,3 +637,63 @@ fn-letsencrypt-symlink-certs() {
   cp "$config_dir/certificates/$fileSafeDomain.crt" "$app_root/tls/server.letsencrypt.crt"
   cp "$config_dir/certificates/$fileSafeDomain.crt" "$app_root/tls/server.crt"
 }
+
+fn-letsencrypt-report-parse-args() {
+  declare desc="strip --format and --global from a report invocation"
+  REPORT_FORMAT="stdout"
+  REPORT_IS_GLOBAL="false"
+  REPORT_ARGS=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        REPORT_FORMAT="$2"
+        shift 2
+        ;;
+      --global)
+        REPORT_IS_GLOBAL="true"
+        shift
+        ;;
+      *)
+        REPORT_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+fn-letsencrypt-report-validate-format() {
+  declare desc="reject --format when combined with an info flag"
+  declare FORMAT="$1" INFO_FLAG="$2"
+  if [[ "$FORMAT" != "stdout" ]] && [[ -n "$INFO_FLAG" ]]; then
+    dokku_log_fail "--format flag cannot be specified when specifying an info flag"
+  fi
+}
+
+fn-letsencrypt-report-filter-global() {
+  declare desc="rewrite flag_map keeping only --letsencrypt-global-* entries"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local filtered=()
+  local flag key
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1)"
+    if [[ "$key" == *"-global-"* ]]; then
+      filtered+=("$flag")
+    fi
+  done
+  flag_map_ref=("${filtered[@]}")
+}
+
+fn-letsencrypt-report-emit-json() {
+  declare desc="emit a flag_map as a JSON object, stripping the --letsencrypt- key prefix"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local json_output="{}"
+  local flag key value
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1 | sed 's/^--letsencrypt-//')"
+    value="$(echo "$flag" | cut -d':' -f2- | sed 's/^ //')"
+    json_output="$(echo "$json_output" | jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}')"
+  done
+  echo "$json_output"
+}

--- a/tests/letsencrypt_report.bats
+++ b/tests/letsencrypt_report.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+  create_app "$APP"
+}
+
+teardown() {
+  cleanup_app "$APP"
+  dokku letsencrypt:set --global graceperiod "" || true
+}
+
+@test "letsencrypt:report renders a stdout report by default" {
+  run dokku letsencrypt:report "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "${APP} letsencrypt information"
+  echo "$output" | grep -q "Letsencrypt active"
+  echo "$output" | grep -q "Letsencrypt computed email"
+}
+
+@test "letsencrypt:report --format json returns valid JSON for an app" {
+  dokku letsencrypt:set "$APP" email "app@dokku.test"
+
+  run dokku letsencrypt:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  email="$(echo "$output" | jq -r '.email')"
+  [ "$email" = "app@dokku.test" ]
+  computed="$(echo "$output" | jq -r '."computed-email"')"
+  [ "$computed" = "app@dokku.test" ]
+}
+
+@test "letsencrypt:report --format json without an app emits one object per app" {
+  run /bin/bash -c "dokku letsencrypt:report --format json | jq -e ."
+  [ "$status" -eq 0 ]
+}
+
+@test "letsencrypt:report --global prints a global header" {
+  run dokku letsencrypt:report --global
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "global letsencrypt information"
+  echo "$output" | grep -q "Letsencrypt global email"
+}
+
+@test "letsencrypt:report --global --format json returns only global keys" {
+  dokku letsencrypt:set --global graceperiod 11111
+
+  run dokku letsencrypt:report --global --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  non_global="$(echo "$output" | jq -r 'keys[]' | grep -v '^global-' || true)"
+  [ -z "$non_global" ]
+  value="$(echo "$output" | jq -r '."global-graceperiod"')"
+  [ "$value" = "11111" ]
+}
+
+@test "letsencrypt:report --format json combined with an info flag is rejected" {
+  run dokku letsencrypt:report "$APP" --format json --letsencrypt-email
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "format flag cannot be specified when specifying an info flag"
+}
+
+@test "letsencrypt:report info flag still returns just that value" {
+  dokku letsencrypt:set "$APP" graceperiod 4242
+  run dokku letsencrypt:report "$APP" --letsencrypt-graceperiod
+  [ "$status" -eq 0 ]
+  [ "$output" = "4242" ]
+}


### PR DESCRIPTION
`letsencrypt:report` previously rejected `--format json` and ignored `--global`, blocking external tooling from probing letsencrypt properties cleanly. Other dokku `:report` subcommands (`nginx:report`, `git:report`, `proxy:report`) have accepted both since dokku/dokku#8499 and dokku/dokku#8500, and external tooling relied on that convention.

This wires both flags into `cmd-letsencrypt-report` and `cmd-letsencrypt-report-single`: `--format json` emits a single JSON object of every letsencrypt property (keys stripped of the `--letsencrypt-` prefix), `--global` restricts the output to global properties only, and the two combine. The existing per-flag query path (e.g. `letsencrypt:report myapp --letsencrypt-email`) is unchanged. Combining `--format json` with an info flag is explicitly rejected with a clear message.

The plugin remains compatible with older Dokku releases: the argument parser, JSON emitter, validate-format check, and global filter live in `internal-functions`, so the plugin does not depend on the `fn-report-*` helpers introduced in Dokku core `v0.38.2`.

Closes #393.