### PR TITLE
refactor: rename lego-docker-args property to lego-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Variable             | Default           | Description
 `dns-provider`       | (none)            | The name of a [valid lego dns-provider](https://go-acme.github.io/lego/dns/)
 `email`              | (none)            | **REQUIRED:** E-mail address to use for registering with Let's Encrypt.
 `graceperiod`        | 2592000 (30 days) | Time in seconds left on a certificate before it should get renewed
-`lego-docker-args`   | (none)            | Extra arguments to pass via `docker run`. See the [lego CLI documentation](https://go-acme.github.io/lego/usage/cli/) for available options.
+`lego-args`          | (none)            | Extra arguments to pass to the `lego` CLI. See the [lego CLI documentation](https://go-acme.github.io/lego/usage/cli/) for available options. Previously named `lego-docker-args`; existing values are migrated automatically on plugin update.
 `server`             | default           | Which ACME server to use. Can be 'default', 'staging' or a URL
 
 You can set a setting using `dokku letsencrypt:set $APP $SETTING_NAME $SETTING_VALUE`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.

--- a/command-functions
+++ b/command-functions
@@ -250,9 +250,9 @@ cmd-letsencrypt-report-single() {
     "--letsencrypt-computed-graceperiod: $(fn-letsencrypt-computed-graceperiod "$APP")"
     "--letsencrypt-global-graceperiod: $(fn-letsencrypt-global-graceperiod)"
     "--letsencrypt-graceperiod: $(fn-letsencrypt-graceperiod "$APP")"
-    "--letsencrypt-computed-lego-docker-args: $(fn-letsencrypt-computed-lego-docker-args "$APP")"
-    "--letsencrypt-global-lego-docker-args: $(fn-letsencrypt-global-lego-docker-args)"
-    "--letsencrypt-lego-docker-args: $(fn-letsencrypt-lego-docker-args "$APP")"
+    "--letsencrypt-computed-lego-args: $(fn-letsencrypt-computed-lego-args "$APP")"
+    "--letsencrypt-global-lego-args: $(fn-letsencrypt-global-lego-args)"
+    "--letsencrypt-lego-args: $(fn-letsencrypt-lego-args "$APP")"
     "--letsencrypt-computed-server: $(fn-letsencrypt-computed-server "$APP")"
     "--letsencrypt-global-server: $(fn-letsencrypt-global-server)"
     "--letsencrypt-server: $(fn-letsencrypt-server "$APP")"
@@ -323,13 +323,13 @@ cmd-letsencrypt-set() {
   declare cmd="letsencrypt:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("dns-provider" "email" "graceperiod" "server" "lego-docker-args")
+  local VALID_KEYS=("dns-provider" "email" "graceperiod" "server" "lego-args")
   [[ "$APP" == "--global" ]] || verify_app_name "$APP"
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}" && [[ "$KEY" != dns-provider-* ]]; then
-    dokku_log_fail "Invalid key specified, valid keys include: dns-provider, dns-provider-*, email, graceperiod, server, lego-docker-args"
+    dokku_log_fail "Invalid key specified, valid keys include: dns-provider, dns-provider-*, email, graceperiod, server, lego-args"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/install
+++ b/install
@@ -25,9 +25,16 @@ fn-letsencrypt-migrate-properties() {
 
   value=$(plugn trigger config-get-global "DOKKU_LETSENCRYPT_ARGS" || true)
   if [[ -n "$value" ]]; then
-    dokku_log_info1 "Migrating deprecated global DOKKU_LETSENCRYPT_ARGS to letsencrypt lego-docker-args property."
-    fn-plugin-property-write "letsencrypt" "--global" "lego-docker-args" "$value"
+    dokku_log_info1 "Migrating deprecated global DOKKU_LETSENCRYPT_ARGS to letsencrypt lego-args property."
+    fn-plugin-property-write "letsencrypt" "--global" "lego-args" "$value"
     DOKKU_QUIET_OUTPUT=1 config_unset --global DOKKU_LETSENCRYPT_ARGS || true
+  fi
+
+  value="$(fn-plugin-property-get-default "letsencrypt" "--global" "lego-docker-args" "")"
+  if [[ -n "$value" ]]; then
+    dokku_log_info1 "Migrating deprecated global lego-docker-args property to lego-args."
+    fn-plugin-property-write "letsencrypt" "--global" "lego-args" "$value"
+    fn-plugin-property-delete "letsencrypt" "--global" "lego-docker-args"
   fi
 
   value=$(plugn trigger config-get-global "DOKKU_LETSENCRYPT_SERVER" || true)
@@ -54,9 +61,16 @@ fn-letsencrypt-migrate-properties() {
 
     value="$(plugn trigger config-get "$app" DOKKU_LETSENCRYPT_ARGS || true)"
     if [[ -n "$value" ]]; then
-      dokku_log_info1 "Migrating deprecated DOKKU_LETSENCRYPT_ARGS to letsencrypt lego-docker-args property for $app."
-      fn-plugin-property-write "letsencrypt" "$app" "lego-docker-args" "$value"
+      dokku_log_info1 "Migrating deprecated DOKKU_LETSENCRYPT_ARGS to letsencrypt lego-args property for $app."
+      fn-plugin-property-write "letsencrypt" "$app" "lego-args" "$value"
       DOKKU_QUIET_OUTPUT=1 config_unset --no-restart "$app" "DOKKU_LETSENCRYPT_ARGS" || true
+    fi
+
+    value="$(fn-plugin-property-get-default "letsencrypt" "$app" "lego-docker-args" "")"
+    if [[ -n "$value" ]]; then
+      dokku_log_info1 "Migrating deprecated lego-docker-args property to lego-args for $app."
+      fn-plugin-property-write "letsencrypt" "$app" "lego-args" "$value"
+      fn-plugin-property-delete "letsencrypt" "$app" "lego-docker-args"
     fi
 
     value="$(plugn trigger config-get "$app" DOKKU_LETSENCRYPT_SERVER || true)"

--- a/internal-functions
+++ b/internal-functions
@@ -190,29 +190,29 @@ fn-letsencrypt-dns-provider() {
   fn-plugin-property-get-default "letsencrypt" "$APP" "dns-provider" ""
 }
 
-fn-letsencrypt-computed-lego-docker-args() {
-  declare desc="get configured lego docker args"
+fn-letsencrypt-computed-lego-args() {
+  declare desc="get configured lego cli args"
   declare APP="$1"
 
-  value="$(fn-letsencrypt-lego-docker-args "$APP")"
+  value="$(fn-letsencrypt-lego-args "$APP")"
   if [[ -z "$value" ]]; then
-    value="$(fn-letsencrypt-global-lego-docker-args)"
+    value="$(fn-letsencrypt-global-lego-args)"
   fi
 
   echo "$value"
 }
 
-fn-letsencrypt-global-lego-docker-args() {
-  declare desc="get configured lego docker args"
+fn-letsencrypt-global-lego-args() {
+  declare desc="get configured lego cli args"
 
-  fn-plugin-property-get-default "letsencrypt" "--global" "lego-docker-args" ""
+  fn-plugin-property-get-default "letsencrypt" "--global" "lego-args" ""
 }
 
-fn-letsencrypt-lego-docker-args() {
-  declare desc="get configured lego docker args"
+fn-letsencrypt-lego-args() {
+  declare desc="get configured lego cli args"
   declare APP="$1"
 
-  fn-plugin-property-get-default "letsencrypt" "$APP" "lego-docker-args" ""
+  fn-plugin-property-get-default "letsencrypt" "$APP" "lego-args" ""
 }
 
 fn-letsencrypt-check-email() {
@@ -254,7 +254,7 @@ fn-letsencrypt-configure-and-get-dir() {
   # lego --cert.timeout is in seconds and defaults to 30
   cert_timeout=30
   email="$(fn-letsencrypt-computed-email "$APP")"
-  extra_args="$(fn-letsencrypt-computed-lego-docker-args "$APP")"
+  extra_args="$(fn-letsencrypt-computed-lego-args "$APP")"
   config="--pem --accept-tos --cert.timeout $cert_timeout --path /certs --server $server --email $email $extra_args $domain_args"
 
   dns_provider="$(fn-letsencrypt-computed-dns-provider "$APP")"

--- a/tests/letsencrypt_cleanup.bats
+++ b/tests/letsencrypt_cleanup.bats
@@ -20,7 +20,7 @@ teardown() {
   baseline_hash="$(basename "$(current_config_dir "$APP")")"
 
   # change config to force a new hash, then enable again
-  dokku letsencrypt:set "$APP" lego-docker-args "--cert.timeout=45"
+  dokku letsencrypt:set "$APP" lego-args "--cert.timeout=45"
   dokku letsencrypt:enable "$APP"
   new_hash="$(basename "$(current_config_dir "$APP")")"
   [ "$baseline_hash" != "$new_hash" ]

--- a/tests/letsencrypt_enable_lego_args.bats
+++ b/tests/letsencrypt_enable_lego_args.bats
@@ -15,8 +15,8 @@ teardown() {
   cleanup_app "$APP"
 }
 
-@test "lego-docker-args is appended to the lego command line" {
-  dokku letsencrypt:set "$APP" lego-docker-args "--cert.timeout=45"
+@test "lego-args is appended to the lego command line" {
+  dokku letsencrypt:set "$APP" lego-args "--cert.timeout=45"
   run dokku letsencrypt:enable "$APP"
   [ "$status" -eq 0 ]
 
@@ -25,11 +25,11 @@ teardown() {
   $SUDO grep -qF -- "--cert.timeout=45" "$current/config"
 }
 
-@test "changing lego-docker-args changes the config hash" {
+@test "changing lego-args changes the config hash" {
   dokku letsencrypt:enable "$APP"
   baseline_hash="$(basename "$(current_config_dir "$APP")")"
 
-  dokku letsencrypt:set "$APP" lego-docker-args "--cert.timeout=45"
+  dokku letsencrypt:set "$APP" lego-args "--cert.timeout=45"
   dokku letsencrypt:enable "$APP"
   new_hash="$(basename "$(current_config_dir "$APP")")"
 

--- a/tests/setup-native.sh
+++ b/tests/setup-native.sh
@@ -67,6 +67,6 @@ sudo dokku letsencrypt:set --global email "${LETSENCRYPT_TEST_EMAIL}"
 # zone-discovery step fails. `--dns.propagation-wait` replaces the SOA
 # walk with a fixed wait, which is plenty since challtestsrv applies
 # `/set-txt` writes immediately.
-sudo dokku letsencrypt:set --global lego-docker-args "--dns.resolvers=172.17.0.1:8053 --dns.propagation-wait=1s"
+sudo dokku letsencrypt:set --global lego-args "--dns.resolvers=172.17.0.1:8053 --dns.propagation-wait=1s"
 
 log "Setup complete"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -44,6 +44,6 @@ dokku letsencrypt:set --global email "${LETSENCRYPT_TEST_EMAIL}"
 # zone-discovery step fails. `--dns.propagation-wait` replaces the SOA
 # walk with a fixed wait, which is plenty since challtestsrv applies
 # `/set-txt` writes immediately.
-dokku letsencrypt:set --global lego-docker-args "--dns.resolvers=172.17.0.1:8053 --dns.propagation-wait=1s"
+dokku letsencrypt:set --global lego-args "--dns.resolvers=172.17.0.1:8053 --dns.propagation-wait=1s"
 
 log "Setup complete"


### PR DESCRIPTION
The property is passed to the `lego` CLI rather than to `docker run`, so the previous name and README description were misleading. Existing values are migrated automatically to the new property on plugin update.