### PR TITLE
feat: add lego-docker-options property for docker run flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Variable             | Default           | Description
 `email`              | (none)            | **REQUIRED:** E-mail address to use for registering with Let's Encrypt.
 `graceperiod`        | 2592000 (30 days) | Time in seconds left on a certificate before it should get renewed
 `lego-args`          | (none)            | Extra arguments to pass to the `lego` CLI. See the [lego CLI documentation](https://go-acme.github.io/lego/usage/cli/) for available options. Previously named `lego-docker-args`; existing values are migrated automatically on plugin update.
+`lego-docker-options`| (none)            | Extra arguments to pass to `docker run` when starting the `lego` container (for volume mounts, extra env files, custom networks, etc.). Distinct from `lego-args`, which targets the `lego` CLI itself.
 `server`             | default           | Which ACME server to use. Can be 'default', 'staging' or a URL
 
 You can set a setting using `dokku letsencrypt:set $APP $SETTING_NAME $SETTING_VALUE`. When looking for a setting, the plugin will first look if it was defined for the current app and fall back to settings defined by `--global`.
@@ -228,7 +229,26 @@ dokku letsencrypt:set --global dns-provider-NAMECHEAP_API_USER user
 dokku letsencrypt:set --global dns-provider-NAMECHEAP_API_KEY key
 ```
 
-Due to limitations in how certain DNS providers work, environment variables _must not_ use the `_FILE` based method for referring to values in files.
+If a DNS provider documents `_FILE`-suffixed environment variables for reading secrets from files, mount the secret file into the `lego` container with `lego-docker-options` and set the corresponding `dns-provider-*_FILE` property to the in-container path. For example:
+
+```shell
+dokku letsencrypt:set --global lego-docker-options "-v /etc/dokku-letsencrypt/cloudflare-token:/secrets/cf-token:ro"
+dokku letsencrypt:set --global dns-provider-CLOUDFLARE_DNS_API_TOKEN_FILE /secrets/cf-token
+```
+
+### Using the `exec` DNS provider
+
+The `lego` [`exec` DNS provider](https://go-acme.github.io/lego/dns/exec/) shells out to a user-supplied script for creating and removing TXT records. The script must be reachable from inside the `lego` container at the path stored in the `EXEC_PATH` environment variable. Use `lego-docker-options` to mount it from the host:
+
+```shell
+# write the script on the dokku host, make it executable
+sudo install -m 0755 /path/on/host/dns.sh /var/lib/dokku/data/letsencrypt/exec-dns.sh
+
+# mount it into the lego container and point exec at it
+dokku letsencrypt:set --global dns-provider exec
+dokku letsencrypt:set --global lego-docker-options "-v /var/lib/dokku/data/letsencrypt/exec-dns.sh:/scripts/dns.sh:ro"
+dokku letsencrypt:set --global dns-provider-EXEC_PATH /scripts/dns.sh
+```
 
 Please see the Lego documentation for your DNS provider for more information on what configuration is necessary to utilize DNS-01 challenges.
 

--- a/command-functions
+++ b/command-functions
@@ -253,6 +253,9 @@ cmd-letsencrypt-report-single() {
     "--letsencrypt-computed-lego-args: $(fn-letsencrypt-computed-lego-args "$APP")"
     "--letsencrypt-global-lego-args: $(fn-letsencrypt-global-lego-args)"
     "--letsencrypt-lego-args: $(fn-letsencrypt-lego-args "$APP")"
+    "--letsencrypt-computed-lego-docker-options: $(fn-letsencrypt-computed-lego-docker-options "$APP")"
+    "--letsencrypt-global-lego-docker-options: $(fn-letsencrypt-global-lego-docker-options)"
+    "--letsencrypt-lego-docker-options: $(fn-letsencrypt-lego-docker-options "$APP")"
     "--letsencrypt-computed-server: $(fn-letsencrypt-computed-server "$APP")"
     "--letsencrypt-global-server: $(fn-letsencrypt-global-server)"
     "--letsencrypt-server: $(fn-letsencrypt-server "$APP")"
@@ -323,13 +326,13 @@ cmd-letsencrypt-set() {
   declare cmd="letsencrypt:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("dns-provider" "email" "graceperiod" "server" "lego-args")
+  local VALID_KEYS=("dns-provider" "email" "graceperiod" "server" "lego-args" "lego-docker-options")
   [[ "$APP" == "--global" ]] || verify_app_name "$APP"
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}" && [[ "$KEY" != dns-provider-* ]]; then
-    dokku_log_fail "Invalid key specified, valid keys include: dns-provider, dns-provider-*, email, graceperiod, server, lego-args"
+    dokku_log_fail "Invalid key specified, valid keys include: dns-provider, dns-provider-*, email, graceperiod, server, lego-args, lego-docker-options"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/internal-functions
+++ b/internal-functions
@@ -35,6 +35,10 @@ fn-letsencrypt-acme-execute-challenge() {
   host_config_dir="$(echo "$config_dirs" | cut -d: -f1)"
   container_config_dir="$(echo "$config_dirs" | cut -d: -f2)"
   read -r -a config <"$container_config_dir/config"
+  local docker_options_argv=()
+  if [[ -f "$container_config_dir/docker_options" ]]; then
+    read -r -a docker_options_argv <"$container_config_dir/docker_options"
+  fi
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
@@ -47,6 +51,7 @@ fn-letsencrypt-acme-execute-challenge() {
     --user $DOKKU_UID:$DOKKU_GID \
     -v "$host_config_dir:/certs" \
     -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
+    "${docker_options_argv[@]}" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
     "${config[@]}" run | sed "s/^/       /"
 
@@ -91,6 +96,10 @@ fn-letsencrypt-acme-revoke() {
   host_config_dir="$(echo "$config_dirs" | cut -d: -f1)"
   container_config_dir="$(echo "$config_dirs" | cut -d: -f2)"
   read -r -a config <"$container_config_dir/config"
+  local docker_options_argv=()
+  if [[ -f "$container_config_dir/docker_options" ]]; then
+    read -r -a docker_options_argv <"$container_config_dir/docker_options"
+  fi
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
@@ -104,6 +113,7 @@ fn-letsencrypt-acme-revoke() {
     -p "$acme_port:$acme_port" \
     -v "$host_config_dir:/certs" \
     -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
+    "${docker_options_argv[@]}" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
     "${config[@]}" revoke | sed "s/^/       /"
 
@@ -215,6 +225,31 @@ fn-letsencrypt-lego-args() {
   fn-plugin-property-get-default "letsencrypt" "$APP" "lego-args" ""
 }
 
+fn-letsencrypt-computed-lego-docker-options() {
+  declare desc="get configured docker run options for the lego container"
+  declare APP="$1"
+
+  value="$(fn-letsencrypt-lego-docker-options "$APP")"
+  if [[ -z "$value" ]]; then
+    value="$(fn-letsencrypt-global-lego-docker-options)"
+  fi
+
+  echo "$value"
+}
+
+fn-letsencrypt-global-lego-docker-options() {
+  declare desc="get configured docker run options for the lego container"
+
+  fn-plugin-property-get-default "letsencrypt" "--global" "lego-docker-options" ""
+}
+
+fn-letsencrypt-lego-docker-options() {
+  declare desc="get configured docker run options for the lego container"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "letsencrypt" "$APP" "lego-docker-options" ""
+}
+
 fn-letsencrypt-check-email() {
   declare desc="Check if an e-mail address is provided globally or for the app"
   declare APP="$1"
@@ -231,7 +266,7 @@ fn-letsencrypt-check-email() {
 fn-letsencrypt-configure-and-get-dir() {
   declare desc="assemble lego command line arguments and create a config hash directory for them"
   declare APP="$1"
-  local config config_dir config_hash dns_provider domain_args domains email extra_args cert_timeout key server value
+  local config config_dir config_hash dns_provider docker_options_value domain_args domains email extra_args cert_timeout key server value
 
   local app_root="$DOKKU_ROOT/$APP"
   local le_root="$app_root/letsencrypt"
@@ -255,6 +290,7 @@ fn-letsencrypt-configure-and-get-dir() {
   cert_timeout=30
   email="$(fn-letsencrypt-computed-email "$APP")"
   extra_args="$(fn-letsencrypt-computed-lego-args "$APP")"
+  docker_options_value="$(fn-letsencrypt-computed-lego-docker-options "$APP")"
   config="--pem --accept-tos --cert.timeout $cert_timeout --path /certs --server $server --email $email $extra_args $domain_args"
 
   dns_provider="$(fn-letsencrypt-computed-dns-provider "$APP")"
@@ -264,7 +300,7 @@ fn-letsencrypt-configure-and-get-dir() {
     config="--http --http.webroot /webroot $config"
   fi
 
-  config_hash=$(echo "$config" | sha1sum | awk '{print $1}')
+  config_hash=$(echo "$config $docker_options_value" | sha1sum | awk '{print $1}')
   config_dir="$le_root/certs/$config_hash"
   mkdir -p "$config_dir"
 
@@ -294,6 +330,7 @@ fn-letsencrypt-configure-and-get-dir() {
 
   # store config settings
   echo "$config" >"$config_dir/config"
+  echo "$docker_options_value" >"$config_dir/docker_options"
 
   # send both host and container path
   # to respect mapped DOKKU_ROOT when running in a container

--- a/tests/letsencrypt_enable_lego_docker_options.bats
+++ b/tests/letsencrypt_enable_lego_docker_options.bats
@@ -47,14 +47,14 @@ teardown() {
 }
 
 @test "lego exec DNS provider issues a cert with a script mounted via lego-docker-options" {
-  # Drop the exec script onto a path that's visible to both the dokku
-  # container (where this test runs) and the host docker daemon (which
-  # actually launches the lego container). DOKKU_HOST_ROOT is set by the
-  # compose stack so that $DOKKU_HOST_ROOT/<app>/... resolves on the host
-  # to the same file we write under /home/dokku/<app>/... here.
-  local script_in_container="/home/dokku/${APP}/letsencrypt/exec-dns.sh"
-  local script_on_host="${DOKKU_HOST_ROOT:-/home/dokku}/${APP}/letsencrypt/exec-dns.sh"
-  $SUDO mkdir -p "$(dirname "$script_in_container")"
+  # The lego container is spawned by the host docker daemon, so the -v
+  # source must resolve on the host: DOKKU_HOST_ROOT is set by the compose
+  # stack so $DOKKU_HOST_ROOT/<app>/... maps to the same file we write under
+  # /home/dokku/<app>/... here. We stage at the app home dir (owned by
+  # dokku:dokku from `apps:create`) and not in letsencrypt/, so dokku can
+  # still create letsencrypt/{account,certs} as itself.
+  local script_in_container="/home/dokku/${APP}/exec-dns.sh"
+  local script_on_host="${DOKKU_HOST_ROOT:-/home/dokku}/${APP}/exec-dns.sh"
   $SUDO cp "${BATS_TEST_DIRNAME}/lego/challtestsrv-dns.sh" "$script_in_container"
   $SUDO chmod 0755 "$script_in_container"
 

--- a/tests/letsencrypt_enable_lego_docker_options.bats
+++ b/tests/letsencrypt_enable_lego_docker_options.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP="$(new_app_name)"
+  DOMAIN="${APP}.${TEST_DOMAIN_BASE}"
+  create_app "$APP"
+  set_domain "$APP" "$DOMAIN"
+  register_a_record "$DOMAIN"
+}
+
+teardown() {
+  clear_a_record "$DOMAIN"
+  cleanup_app "$APP"
+  dokku letsencrypt:set --global dns-provider "" || true
+  dokku letsencrypt:set --global dns-provider-EXEC_PATH "" || true
+}
+
+@test "lego-docker-options is persisted to the per-hash docker_options file" {
+  dokku letsencrypt:set "$APP" lego-docker-options "-v /tmp/sentinel:/sentinel:ro"
+  # Configuration directory is created before the ACME network round-trip,
+  # so the plumbing assertion holds regardless of whether issuance succeeds.
+  dokku letsencrypt:enable "$APP" || true
+
+  local found=0
+  for dir in $(config_hash_dirs "$APP"); do
+    if $SUDO grep -qF -- "-v /tmp/sentinel:/sentinel:ro" "$dir/docker_options" 2>/dev/null; then
+      found=1
+      break
+    fi
+  done
+  [ "$found" -eq 1 ]
+}
+
+@test "changing lego-docker-options creates a new config hash directory" {
+  dokku letsencrypt:enable "$APP" || true
+  local baseline_count
+  baseline_count="$(config_hash_dirs "$APP" | wc -l | tr -d ' ')"
+
+  dokku letsencrypt:set "$APP" lego-docker-options "-v /tmp/sentinel:/sentinel:ro"
+  dokku letsencrypt:enable "$APP" || true
+  local new_count
+  new_count="$(config_hash_dirs "$APP" | wc -l | tr -d ' ')"
+
+  [ "$new_count" -gt "$baseline_count" ]
+}
+
+@test "lego exec DNS provider issues a cert with a script mounted via lego-docker-options" {
+  # Drop the exec script onto a path that's visible to both the dokku
+  # container (where this test runs) and the host docker daemon (which
+  # actually launches the lego container). DOKKU_HOST_ROOT is set by the
+  # compose stack so that $DOKKU_HOST_ROOT/<app>/... resolves on the host
+  # to the same file we write under /home/dokku/<app>/... here.
+  local script_in_container="/home/dokku/${APP}/letsencrypt/exec-dns.sh"
+  local script_on_host="${DOKKU_HOST_ROOT:-/home/dokku}/${APP}/letsencrypt/exec-dns.sh"
+  $SUDO mkdir -p "$(dirname "$script_in_container")"
+  $SUDO cp "${BATS_TEST_DIRNAME}/lego/challtestsrv-dns.sh" "$script_in_container"
+  $SUDO chmod 0755 "$script_in_container"
+
+  dokku letsencrypt:set --global dns-provider exec
+  dokku letsencrypt:set --global dns-provider-EXEC_PATH /scripts/dns.sh
+  dokku letsencrypt:set "$APP" lego-docker-options "-v ${script_on_host}:/scripts/dns.sh:ro"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+
+  assert_cert_exists "$APP"
+  assert_cert_issued_by_pebble "$APP"
+  assert_cert_san_contains "$APP" "$DOMAIN"
+}

--- a/tests/letsencrypt_set.bats
+++ b/tests/letsencrypt_set.bats
@@ -59,6 +59,15 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "lego-docker-options is accepted" {
+  run dokku letsencrypt:set "$APP" lego-docker-options "-v /tmp/foo:/foo:ro"
+  [ "$status" -eq 0 ]
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-lego-docker-options
+  [ "$status" -eq 0 ]
+  [ "$output" = "-v /tmp/foo:/foo:ro" ]
+}
+
 @test "letsencrypt:report shows expected fields when nothing is set" {
   run dokku letsencrypt:report "$APP"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The plugin runs `lego` inside a sealed `docker run` and previously exposed no way to add `-v` mounts, `-e` flags, or other docker run options. That blocks the `exec` DNS provider, which needs a user script reachable at `EXEC_PATH` inside the container, and forces `_FILE`-suffixed credential env vars to be set without the underlying secret file being mountable. The new property is splatted into the docker run argv before the image name for both the issuance and revocation paths, and its value participates in the config hash so changes invalidate the cached per-hash directory.

Resolves #387.