### PR TITLE
feat: skip letsencrypt:enable when a valid certificate already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ dokku letsencrypt:help
     letsencrypt:cleanup <app>               Cleanup stale certificates and configurations
     letsencrypt:cron-job <--add|--remove>   Add or remove an auto-renewal cronjob
     letsencrypt:disable <app>               Disable letsencrypt for an app
-    letsencrypt:enable <app>                Enable or renew letsencrypt for an app
+    letsencrypt:enable <app> [--force]      Enable or renew letsencrypt for an app (skipped when a valid certificate already exists unless --force is set)
     letsencrypt:list                        List letsencrypt-secured apps with certificate expiry
     letsencrypt:report [<app>|--global]     Display a letsencrypt report for one or more apps
     letsencrypt:revoke <app>                Revoke letsencrypt certificate for app
@@ -252,15 +252,23 @@ dokku letsencrypt:set --global dns-provider-EXEC_PATH /scripts/dns.sh
 
 Please see the Lego documentation for your DNS provider for more information on what configuration is necessary to utilize DNS-01 challenges.
 
-## Conditional enabling
+## Idempotent enable
 
-`dokku letsencrypt:enable <app>` enables letsencrypt for an application or renews the certificate. This may lead to hitting rate limits with letsencrypt.
+`dokku letsencrypt:enable <app>` is safe to call on every deploy. It only contacts the ACME server when one of the following is true:
 
-To avoid renewals, for example in a continuous deployment scenario, you could first check if letsencrypt has already been enabled for the app:
+- the app does not currently have a Let's Encrypt certificate installed
+- the app's domains, email, server, `lego-args`, `lego-docker-options`, or `dns-provider` have changed since the certificate was issued
+- the certificate is within its renewal grace period (see the `graceperiod` configuration variable)
+
+In every other case the command exits successfully without touching nginx, the lego container, or the ACME server. This avoids running into Let's Encrypt rate limits when the same app is redeployed many times in a short window (for example, CI-driven review apps).
+
+To force a new certificate request even when the existing certificate is still valid, pass `--force`:
 
 ```shell
-dokku letsencrypt:active <app> || dokku letsencrypt:enable <app>
+dokku letsencrypt:enable <app> --force
 ```
+
+This is useful when copying certificates between servers (the host did not issue the cert, so the ACME account on the new host has no record of it) or when manually rotating an existing certificate.
 
 ## License
 

--- a/command-functions
+++ b/command-functions
@@ -164,16 +164,31 @@ cmd-letsencrypt-enable() {
   declare cmd="letsencrypt:enable"
   [[ "$1" == "$cmd" ]] && shift 1
 
+  local FORCE=false
+  local positional=()
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --force | -f)
+        FORCE=true
+        ;;
+      *)
+        positional+=("$arg")
+        ;;
+    esac
+  done
+  set -- "${positional[@]}"
+
   # Support --app/$DOKKU_APP_NAME flag by reordering args into "$cmd $DOKKU_APP_NAME $@"
   [[ -n "$DOKKU_APP_NAME" ]] && set -- $DOKKU_APP_NAME $@
 
   declare APP="$1"
   if [[ "$APP" == "--all" ]]; then
     for app in $(dokku_apps); do
-      fn-letsencrypt-enable "$app"
+      fn-letsencrypt-enable "$app" "$FORCE"
     done
   else
-    fn-letsencrypt-enable "$APP"
+    fn-letsencrypt-enable "$APP" "$FORCE"
   fi
 }
 

--- a/help-functions
+++ b/help-functions
@@ -32,7 +32,7 @@ fn-help-content() {
     letsencrypt:cleanup <app>, Remove stale certificate directories for app
     letsencrypt:cron-job [--add --remove], Add or remove a cron job that periodically calls auto-renew.
     letsencrypt:disable <app>, Disable letsencrypt for an app
-    letsencrypt:enable <app>, Enable or renew letsencrypt for an app
+    letsencrypt:enable <app> [--force], Enable or renew letsencrypt for an app (skipped when a valid certificate already exists unless --force is set)
     letsencrypt:help, Display letsencrypt help
     letsencrypt:list, List letsencrypt-secured apps with certificate expiry times
     letsencrypt:report [<app>|--global] [<flag>] [--format json], Display a letsencrypt report for one or more apps

--- a/internal-functions
+++ b/internal-functions
@@ -263,34 +263,22 @@ fn-letsencrypt-check-email() {
   fi
 }
 
-fn-letsencrypt-configure-and-get-dir() {
-  declare desc="assemble lego command line arguments and create a config hash directory for them"
+fn-letsencrypt-config-string() {
+  declare desc="assemble the lego command-line config string (no side effects)"
   declare APP="$1"
-  local config config_dir config_hash dns_provider docker_options_value domain_args domains email extra_args cert_timeout key server value
+  local cert_timeout config dns_provider domain domain_args domains email extra_args server
 
-  local app_root="$DOKKU_ROOT/$APP"
-  local le_root="$app_root/letsencrypt"
-  mkdir -p "$DOKKU_ROOT/$APP/letsencrypt/account"
-
-  # build up a string of all certificate-controlling configuration settings.
-  # this will be used to determine the folder name for the account key and certificates
-
-  # get the selected ACME server
   server="$(fn-letsencrypt-computed-server "$APP")"
 
-  # construct domain arguments
   domains="$(get_app_domains "$APP")"
   domain_args=''
   for domain in $domains; do
-    dokku_log_verbose " - Domain '$domain'" >&2
     domain_args="$domain_args --domains $domain"
   done
 
-  # lego --cert.timeout is in seconds and defaults to 30
   cert_timeout=30
   email="$(fn-letsencrypt-computed-email "$APP")"
   extra_args="$(fn-letsencrypt-computed-lego-args "$APP")"
-  docker_options_value="$(fn-letsencrypt-computed-lego-docker-options "$APP")"
   config="--pem --accept-tos --cert.timeout $cert_timeout --path /certs --server $server --email $email $extra_args $domain_args"
 
   dns_provider="$(fn-letsencrypt-computed-dns-provider "$APP")"
@@ -300,7 +288,37 @@ fn-letsencrypt-configure-and-get-dir() {
     config="--http --http.webroot /webroot $config"
   fi
 
-  config_hash=$(echo "$config $docker_options_value" | sha1sum | awk '{print $1}')
+  echo "$config"
+}
+
+fn-letsencrypt-config-hash() {
+  declare desc="compute the sha1 hash that names an app's lego config directory"
+  declare APP="$1"
+  local config docker_options_value
+
+  config="$(fn-letsencrypt-config-string "$APP")"
+  docker_options_value="$(fn-letsencrypt-computed-lego-docker-options "$APP")"
+  echo "$config $docker_options_value" | sha1sum | awk '{print $1}'
+}
+
+fn-letsencrypt-configure-and-get-dir() {
+  declare desc="assemble lego command line arguments and create a config hash directory for them"
+  declare APP="$1"
+  local config config_dir config_hash dns_provider docker_options_value domain key value
+
+  local app_root="$DOKKU_ROOT/$APP"
+  local le_root="$app_root/letsencrypt"
+  mkdir -p "$DOKKU_ROOT/$APP/letsencrypt/account"
+
+  for domain in $(get_app_domains "$APP"); do
+    dokku_log_verbose " - Domain '$domain'" >&2
+  done
+
+  config="$(fn-letsencrypt-config-string "$APP")"
+  docker_options_value="$(fn-letsencrypt-computed-lego-docker-options "$APP")"
+  dns_provider="$(fn-letsencrypt-computed-dns-provider "$APP")"
+
+  config_hash="$(fn-letsencrypt-config-hash "$APP")"
   config_dir="$le_root/certs/$config_hash"
   mkdir -p "$config_dir"
 
@@ -445,7 +463,7 @@ fn-letsencrypt-email() {
 }
 
 fn-letsencrypt-enable() {
-  declare APP="$1"
+  declare APP="$1" FORCE="${2:-false}"
   local EXIT_CODE=0
   local domain
 
@@ -460,6 +478,13 @@ fn-letsencrypt-enable() {
   dokku_log_info2 "Enabling letsencrypt for $APP"
 
   fn-letsencrypt-check-email "$APP"
+
+  if [[ "$FORCE" != "true" ]] && ! fn-letsencrypt-needs-issue "$APP"; then
+    dokku_log_info1 "Certificate is still valid for $APP, skipping certificate request"
+    dokku_log_info1 "Pass --force to letsencrypt:enable to request a new certificate anyway"
+    return 0
+  fi
+
   fn-letsencrypt-acme-proxy-enable "$APP"
   fn-letsencrypt-acme-execute-challenge "$APP" || EXIT_CODE=$? # remove ACME proxy even if this fails
   fn-letsencrypt-acme-proxy-disable "$APP"
@@ -471,6 +496,40 @@ fn-letsencrypt-enable() {
 
   dokku_log_warn "Failed to setup letsencrypt"
   DOKKU_FAIL_EXIT_CODE="$EXIT_CODE" dokku_log_fail "Check log output for further information on failure"
+}
+
+fn-letsencrypt-needs-issue() {
+  declare desc="return 0 when the app needs a fresh certificate, 1 when the current one is still valid"
+  declare APP="$1"
+  local current_link configured_hash current_hash expiry grace_period time_to_renewal
+
+  if [[ "$(fn-letsencrypt-is-active "$APP")" != "true" ]]; then
+    return 0
+  fi
+
+  current_link="$DOKKU_ROOT/$APP/letsencrypt/certs/current"
+  if [[ ! -L "$current_link" ]]; then
+    return 0
+  fi
+
+  configured_hash="$(fn-letsencrypt-config-hash "$APP")"
+  current_hash="$(basename "$(readlink "$current_link")")"
+  if [[ "$current_hash" != "$configured_hash" ]]; then
+    return 0
+  fi
+
+  expiry="$(fn-letsencrypt-expiration "$APP")"
+  if [[ -z "$expiry" ]]; then
+    return 0
+  fi
+
+  grace_period="$(fn-letsencrypt-computed-graceperiod "$APP")"
+  time_to_renewal=$((expiry - grace_period - $(date +%s)))
+  if [[ $time_to_renewal -lt 0 ]]; then
+    return 0
+  fi
+
+  return 1
 }
 
 fn-letsencrypt-expiration() {

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -64,6 +64,9 @@ teardown() {
 }
 
 @test "letsencrypt:enable is a no-op when a valid cert already exists" {
+  # Pebble issues 24h certs; shrink the grace period so the freshly issued
+  # cert is comfortably outside it.
+  dokku letsencrypt:set "$APP" graceperiod 60
   dokku letsencrypt:enable "$APP"
   before="$(current_config_dir "$APP")"
 
@@ -77,6 +80,7 @@ teardown() {
 }
 
 @test "letsencrypt:enable --force reissues even when a valid cert exists" {
+  dokku letsencrypt:set "$APP" graceperiod 60
   dokku letsencrypt:enable "$APP"
   before_dir="$(current_config_dir "$APP")"
 
@@ -91,6 +95,7 @@ teardown() {
 }
 
 @test "letsencrypt:enable reissues when a new domain is added" {
+  dokku letsencrypt:set "$APP" graceperiod 60
   dokku letsencrypt:enable "$APP"
   assert_cert_san_contains "$APP" "$DOMAIN"
 

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -62,3 +62,48 @@ teardown() {
   [ "$status" -ne 0 ]
   echo "$output" | grep -qi "no domains"
 }
+
+@test "letsencrypt:enable is a no-op when a valid cert already exists" {
+  dokku letsencrypt:enable "$APP"
+  before="$(current_config_dir "$APP")"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "still valid"
+  ! echo "$output" | grep -qi "Certificate retrieved successfully"
+
+  after="$(current_config_dir "$APP")"
+  [ "$before" = "$after" ]
+}
+
+@test "letsencrypt:enable --force reissues even when a valid cert exists" {
+  dokku letsencrypt:enable "$APP"
+  before_dir="$(current_config_dir "$APP")"
+
+  run dokku letsencrypt:enable "$APP" --force
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "Certificate retrieved successfully"
+  ! echo "$output" | grep -qi "still valid"
+
+  after_dir="$(current_config_dir "$APP")"
+  # no config changed, so the same hash dir should still be in use
+  [ "$before_dir" = "$after_dir" ]
+}
+
+@test "letsencrypt:enable reissues when a new domain is added" {
+  dokku letsencrypt:enable "$APP"
+  assert_cert_san_contains "$APP" "$DOMAIN"
+
+  EXTRA_DOMAIN="extra.${APP}.${TEST_DOMAIN_BASE}"
+  register_a_record "$EXTRA_DOMAIN"
+  add_domain "$APP" "$EXTRA_DOMAIN"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "Certificate retrieved successfully"
+
+  assert_cert_san_contains "$APP" "$DOMAIN"
+  assert_cert_san_contains "$APP" "$EXTRA_DOMAIN"
+
+  clear_a_record "$EXTRA_DOMAIN"
+}


### PR DESCRIPTION
## Summary

`letsencrypt:enable` is now a no-op when the app has a Let's Encrypt certificate that covers the configured request and is outside its renewal grace period, matching the heuristic used by `auto-renew`. Pass `--force` to bypass the check and request a new certificate anyway (useful when migrating certs between hosts).

The check compares the `current` symlink against a freshly computed config hash, so adding a domain or changing `email`, `server`, `lego-args`, `lego-docker-options`, or `dns-provider` still triggers a fresh request - the case [#256](https://github.com/dokku/dokku-letsencrypt/issues/256) calls out for `post-domains-update`. With this in place, calling `letsencrypt:enable` on every deploy is safe and no longer burns through Let's Encrypt's 5-certs-per-week-per-domain-set rate limit.

Fixes #256.