### PR TITLE
feat: allow disabling dns-provider per app via 'none' sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ dokku letsencrypt:set --global dns-provider-EXEC_PATH /scripts/dns.sh
 
 Please see the Lego documentation for your DNS provider for more information on what configuration is necessary to utilize DNS-01 challenges.
 
+### Disabling DNS-01 for a single app
+
+When a global `dns-provider` is set but a particular app's domain is not managed by that provider, set the app's `dns-provider` to `none` to force HTTP-01 for that app only:
+
+```shell
+dokku letsencrypt:set <app> dns-provider none
+```
+
+Setting the property to an empty string (`dokku letsencrypt:set <app> dns-provider ""`) deletes the app-level value and falls back to the global setting; `none` is the explicit opt-out. The `none` sentinel is also accepted at `--global` scope, where it behaves identically to leaving the property unset.
+
 ## Idempotent enable
 
 `dokku letsencrypt:enable <app>` is safe to call on every deploy. It only contacts the ACME server when one of the following is true:

--- a/internal-functions
+++ b/internal-functions
@@ -176,12 +176,20 @@ fn-letsencrypt-acme-proxy-enable() {
 }
 
 fn-letsencrypt-computed-dns-provider() {
-  declare desc="get configured dns provider"
+  declare desc="get configured dns provider, with 'none' as an explicit opt-out sentinel"
   declare APP="$1"
+  local value
 
   value="$(fn-letsencrypt-dns-provider "$APP")"
+  if [[ "$value" == "none" ]]; then
+    echo ""
+    return
+  fi
   if [[ -z "$value" ]]; then
     value="$(fn-letsencrypt-global-dns-provider)"
+  fi
+  if [[ "$value" == "none" ]]; then
+    value=""
   fi
 
   echo "$value"

--- a/tests/letsencrypt_set.bats
+++ b/tests/letsencrypt_set.bats
@@ -10,6 +10,7 @@ setup() {
 teardown() {
   cleanup_app "$APP"
   dokku letsencrypt:set --global graceperiod "" || true
+  dokku letsencrypt:set --global dns-provider "" || true
 }
 
 @test "letsencrypt:set writes app-level property" {
@@ -66,6 +67,38 @@ teardown() {
   run dokku letsencrypt:report "$APP" --letsencrypt-lego-docker-options
   [ "$status" -eq 0 ]
   [ "$output" = "-v /tmp/foo:/foo:ro" ]
+}
+
+@test "app-level dns-provider 'none' overrides a global dns-provider" {
+  dokku letsencrypt:set --global dns-provider exec
+  dokku letsencrypt:set "$APP" dns-provider none
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-computed-dns-provider
+  [ "$status" -ne 0 ]
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-dns-provider
+  [ "$status" -eq 0 ]
+  [ "$output" = "none" ]
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-global-dns-provider
+  [ "$status" -eq 0 ]
+  [ "$output" = "exec" ]
+}
+
+@test "global dns-provider 'none' is treated as empty in computed value" {
+  dokku letsencrypt:set --global dns-provider none
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-computed-dns-provider
+  [ "$status" -ne 0 ]
+}
+
+@test "app-level dns-provider override still works for a real provider" {
+  dokku letsencrypt:set --global dns-provider exec
+  dokku letsencrypt:set "$APP" dns-provider route53
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-computed-dns-provider
+  [ "$status" -eq 0 ]
+  [ "$output" = "route53" ]
 }
 
 @test "letsencrypt:report shows expected fields when nothing is set" {


### PR DESCRIPTION
Setting a global `dns-provider` previously left no way to opt a single app out of DNS-01 validation, since clearing the app-level value just fell back to the global setting. Setting an app's `dns-provider` to `none` now resolves to an empty computed value, forcing HTTP-01 for that app while leaving other apps on the global provider. `none` is also accepted at `--global` scope, where it behaves the same as leaving the property unset.

Closes #331.