### PR TITLE
feat: skip the '_' nginx default-vhost domain when issuing certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ dokku domains:add 00-default mydomain.com
 dokku letsencrypt:enable 00-default
 ```
 
+## Default-vhost (`_`) domain
+
+Dokku 0.30.4 added support for the literal `_` domain as an Nginx default catch-all vhost. Let's Encrypt rejects `_` as an invalid identifier, so this plugin silently drops it from the certificate's SAN list and requests a certificate for the remaining domains. An app whose only domain is `_` cannot be enabled and falls into the existing "no domains detected" error path.
+
 ## DNS-01 Challenge
 
 > Functionality sponsored by [Orca Scan Ltd](https://orcascan.com/).

--- a/internal-functions
+++ b/internal-functions
@@ -130,7 +130,7 @@ fn-letsencrypt-acme-revoke() {
     return
   fi
 
-  local domain="$(get_app_domains "$APP" | xargs | awk '{print $1}')"
+  local domain="$(fn-letsencrypt-app-domains "$APP" | xargs | awk '{print $1}')"
 
   # removing the certificate will automatically reconfigure nginx
   if [[ -z $DOKKU_APP_NAME ]]; then
@@ -258,6 +258,12 @@ fn-letsencrypt-lego-docker-options() {
   fn-plugin-property-get-default "letsencrypt" "$APP" "lego-docker-options" ""
 }
 
+fn-letsencrypt-app-domains() {
+  declare desc="list app domains, skipping the '_' nginx default-vhost sentinel"
+  declare APP="$1"
+  get_app_domains "$APP" | grep -vxF '_' || true
+}
+
 fn-letsencrypt-check-email() {
   declare desc="Check if an e-mail address is provided globally or for the app"
   declare APP="$1"
@@ -278,7 +284,7 @@ fn-letsencrypt-config-string() {
 
   server="$(fn-letsencrypt-computed-server "$APP")"
 
-  domains="$(get_app_domains "$APP")"
+  domains="$(fn-letsencrypt-app-domains "$APP")"
   domain_args=''
   for domain in $domains; do
     domain_args="$domain_args --domains $domain"
@@ -318,7 +324,7 @@ fn-letsencrypt-configure-and-get-dir() {
   local le_root="$app_root/letsencrypt"
   mkdir -p "$DOKKU_ROOT/$APP/letsencrypt/account"
 
-  for domain in $(get_app_domains "$APP"); do
+  for domain in $(fn-letsencrypt-app-domains "$APP"); do
     dokku_log_verbose " - Domain '$domain'" >&2
   done
 
@@ -426,7 +432,7 @@ fn-letsencrypt-create-root() {
     fi
 
     sigil -f "$PLUGIN_AVAILABLE_PATH/letsencrypt/templates/default-nginx.conf.sigil" \
-      DOMAINS="$(get_app_domains "$APP" | xargs)" DOKKU_ROOT="$DOKKU_ROOT" APP="$APP" \
+      DOMAINS="$(fn-letsencrypt-app-domains "$APP" | xargs)" DOKKU_ROOT="$DOKKU_ROOT" APP="$APP" \
       NGINX_ACCESS_LOG_FORMAT="$NGINX_ACCESS_LOG_FORMAT" NGINX_ACCESS_LOG_PATH="$NGINX_ACCESS_LOG_PATH" \
       NGINX_ERROR_LOG_PATH="$NGINX_ERROR_LOG_PATH" \
       >"$DOKKU_ROOT/$APP/nginx.conf"
@@ -477,7 +483,7 @@ fn-letsencrypt-enable() {
 
   verify_app_name "$APP"
 
-  domain="$(get_app_domains "$APP" | xargs | awk '{print $1}')"
+  domain="$(fn-letsencrypt-app-domains "$APP" | xargs | awk '{print $1}')"
   if [[ -z "$domain" ]]; then
     dokku_log_warn "No domains detected for $APP"
     return 1
@@ -638,7 +644,7 @@ fn-letsencrypt-is-active() {
     return
   fi
 
-  domain="$(get_app_domains "$APP" | xargs | awk '{print $1}')"
+  domain="$(fn-letsencrypt-app-domains "$APP" | xargs | awk '{print $1}')"
 
   # check if certificate is identical to the current let's encrypt certificate by comparing SHA1 hashes
   local cert_sha1
@@ -733,7 +739,7 @@ fn-letsencrypt-symlink-certs() {
 
   # install the let's encrypt certificate for the app
   unset DOKKU_APP_NAME
-  domain="$(get_app_domains "$APP" | xargs | awk '{print $1}')"
+  domain="$(fn-letsencrypt-app-domains "$APP" | xargs | awk '{print $1}')"
   local fileSafeDomain
   fileSafeDomain="${domain/\*/_}" # wildcards are using *.example.com which have certificates named _.example.com
   dokku certs:add "$APP" "$config_dir/certificates/$fileSafeDomain.pem" "$config_dir/certificates/$fileSafeDomain.key"

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -94,6 +94,28 @@ teardown() {
   [ "$before_dir" = "$after_dir" ]
 }
 
+@test "letsencrypt:enable skips the '_' default-vhost domain when other domains are present" {
+  add_domain "$APP" "_"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+
+  assert_cert_exists "$APP"
+  assert_cert_san_contains "$APP" "$DOMAIN"
+
+  crt="$(cert_path_for "$APP")"
+  ! cert_san "$crt" | grep -qE '(^| )_($|,)'
+}
+
+@test "letsencrypt:enable fails when '_' is the only domain" {
+  dokku domains:clear "$APP"
+  set_domain "$APP" "_"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "no domains"
+}
+
 @test "letsencrypt:enable reissues when a new domain is added" {
   dokku letsencrypt:set "$APP" graceperiod 60
   dokku letsencrypt:enable "$APP"


### PR DESCRIPTION
## Summary

Dokku 0.30.4 introduced the literal `_` domain as a sentinel for an nginx default catch-all vhost. Let's Encrypt rejects `_` as an invalid identifier, which currently fails the entire certificate request even when valid domains are also present. The plugin now strips `_` from the domain list it forwards to lego, certificate filenames, and the temporary ACME nginx config; an app whose only domain is `_` falls into the existing "no domains detected" error path.

Fixes #306.