### PR TITLE
feat: show auto-renew status when cron-job called without flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ dokku letsencrypt:help
     letsencrypt:auto-renew                  Auto-renew all apps secured by letsencrypt if renewal is necessary
     letsencrypt:auto-renew <app>            Auto-renew app if renewal is necessary
     letsencrypt:cleanup <app>               Cleanup stale certificates and configurations
-    letsencrypt:cron-job <--add|--remove>   Add or remove an auto-renewal cronjob
+    letsencrypt:cron-job [--add|--remove]   Add, remove, or display the status of the auto-renewal cronjob
     letsencrypt:disable <app>               Disable letsencrypt for an app
     letsencrypt:enable <app> [--force]      Enable or renew letsencrypt for an app (skipped when a valid certificate already exists unless --force is set)
     letsencrypt:list                        List letsencrypt-secured apps with certificate expiry
@@ -101,6 +101,8 @@ This can be done using the following command:
 ```shell
 dokku letsencrypt:cron-job --add
 ```
+
+Running `dokku letsencrypt:cron-job` without a flag reports whether the auto-renewal cron job is currently enabled.
 
 ## Configuration
 

--- a/command-functions
+++ b/command-functions
@@ -128,8 +128,16 @@ cmd-letsencrypt-cron-job() {
     fn-letsencrypt-cron-job-add
   elif [[ "$FLAG" == "--remove" ]]; then
     fn-letsencrypt-cron-job-remove
+  elif [[ -z "$FLAG" ]]; then
+    if [[ "$(fn-letsencrypt-is-autorenew-enabled)" == "true" ]]; then
+      dokku_log_info2_quiet "Auto-renew cron job is enabled"
+      dokku_log_verbose "Run 'dokku letsencrypt:cron-job --remove' to disable."
+    else
+      dokku_log_info2_quiet "Auto-renew cron job is not enabled"
+      dokku_log_verbose "Run 'dokku letsencrypt:cron-job --add' to enable."
+    fi
   else
-    dokku_log_verbose "Specify --add or --remove to modify the cron-job"
+    dokku_log_fail "Invalid flag '${FLAG}', specify --add, --remove, or no flag to display status."
   fi
 }
 

--- a/help-functions
+++ b/help-functions
@@ -30,7 +30,7 @@ fn-help-content() {
     letsencrypt:active <app>, Verify if letsencrypt is active for an app
     letsencrypt:auto-renew [<app>], Auto-renew app if renewal is necessary
     letsencrypt:cleanup <app>, Remove stale certificate directories for app
-    letsencrypt:cron-job [--add --remove], Add or remove a cron job that periodically calls auto-renew.
+    letsencrypt:cron-job [--add|--remove], Add, remove, or display the status of the auto-renewal cron job.
     letsencrypt:disable <app>, Disable letsencrypt for an app
     letsencrypt:enable <app> [--force], Enable or renew letsencrypt for an app (skipped when a valid certificate already exists unless --force is set)
     letsencrypt:help, Display letsencrypt help

--- a/tests/letsencrypt_cron_job.bats
+++ b/tests/letsencrypt_cron_job.bats
@@ -36,3 +36,28 @@ teardown() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "letsencrypt:auto-renew"
 }
+
+@test "cron-job without flags reports disabled when autorenew flag is absent" {
+  dokku letsencrypt:cron-job --remove >/dev/null 2>&1 || true
+
+  run dokku letsencrypt:cron-job
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Auto-renew cron job is not enabled"
+  echo "$output" | grep -q -- "--add"
+}
+
+@test "cron-job without flags reports enabled when autorenew flag is present" {
+  dokku letsencrypt:cron-job --add
+
+  run dokku letsencrypt:cron-job
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Auto-renew cron job is enabled"
+  ! echo "$output" | grep -q "not enabled"
+  echo "$output" | grep -q -- "--remove"
+}
+
+@test "cron-job rejects an unknown flag" {
+  run dokku letsencrypt:cron-job --bogus
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "Invalid flag"
+}


### PR DESCRIPTION
Running `dokku letsencrypt:cron-job` with no argument previously printed a generic "specify --add or --remove" hint. It now reports whether the auto-renew cron job is currently installed by reading the `${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew` flag and prints the inverse command needed to flip the state. An unknown flag now fails the command instead of silently falling through to the hint message.

Closes #221.