### PR TITLE
fix: detect and surface acme rate-limit errors from lego

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ dokku letsencrypt:enable foo
 
 While playing around with this plugin, you might want to switch to the let's encrypt staging server by running `dokku letsencrypt:set myapp server  staging` to enjoy much higher rate limits and switching back to the real server by running `dokku letsencrypt:set myapp server` once you are ready.
 
+When the ACME server returns a rate-limit response, `letsencrypt:enable` exits non-zero and prints a dedicated warning that points at the [Let's Encrypt rate-limits documentation](https://letsencrypt.org/docs/rate-limits/) and suggests switching to the staging server while iterating. The full lego output is still printed above the warning, so the specific limit that was hit (for example "too many certificates already issued" or "too many failed authorizations") remains visible.
+
 ## Generating a Cert for multiple domains
 
 Your [default dokku app](https://dokku.com/docs/networking/proxies/nginx/?h=default+site#default-site) is accessible under the root domain too. So if you have an application `00-default` that is running under `00-default.mydomain.com` it is accessible under `mydomain.com` too. Now if you enable letsencrypt for your `00-default` application, it is not accessible anymore on `mydomain.com`. You can add the root domain to your dokku domains by typing:

--- a/internal-functions
+++ b/internal-functions
@@ -10,6 +10,23 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
+fn-letsencrypt-detect-rate-limit() {
+  declare desc="return 0 when the captured lego log shows an ACME rate-limit response"
+  declare LOG_PATH="$1"
+
+  [[ -f "$LOG_PATH" ]] || return 1
+  grep -qE 'urn:ietf:params:acme:error:rateLimited|\b429\b.*[Tt]oo [Mm]any [Rr]equests|too many certificates|too many failed authorizations' "$LOG_PATH"
+}
+
+fn-letsencrypt-log-rate-limit() {
+  declare desc="emit a friendly warning when the ACME server has rate-limited the request"
+  declare APP="$1"
+
+  dokku_log_warn "Let's Encrypt rate-limited this request."
+  dokku_log_warn "See https://letsencrypt.org/docs/rate-limits/ for the active limits and remediation guidance."
+  dokku_log_warn "Use 'dokku letsencrypt:set ${APP:-<app>} server staging' while iterating to avoid the production limits."
+}
+
 fn-letsencrypt-acme-execute-challenge() {
   declare desc="perform actual ACME validation procedure"
   declare APP="$1"
@@ -42,6 +59,8 @@ fn-letsencrypt-acme-execute-challenge() {
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
+  local lego_log
+  lego_log="$(mktemp)"
   set +e
   export DOKKU_UID=$(id -u)
   export DOKKU_GID=$(id -g)
@@ -53,9 +72,9 @@ fn-letsencrypt-acme-execute-challenge() {
     -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
     "${docker_options_argv[@]}" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
-    "${config[@]}" run | sed "s/^/       /"
+    "${config[@]}" run 2>&1 | tee "$lego_log" | sed "s/^/       /"
 
-  local exit_code=$?
+  local exit_code=${PIPESTATUS[0]}
   set -e
 
   if [[ "$FAKE_NGINX_CONF" == "true" ]]; then
@@ -63,9 +82,15 @@ fn-letsencrypt-acme-execute-challenge() {
   fi
 
   if [[ $exit_code != 0 ]]; then
+    if fn-letsencrypt-detect-rate-limit "$lego_log"; then
+      fn-letsencrypt-log-rate-limit "$APP"
+    fi
+    rm -f "$lego_log"
     dokku_log_info1 "Certificate retrieval failed!"
     return $exit_code
   fi
+
+  rm -f "$lego_log"
 
   # got certificate
   dokku_log_info1 "Certificate retrieved successfully."
@@ -103,6 +128,8 @@ fn-letsencrypt-acme-revoke() {
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
+  local lego_log
+  lego_log="$(mktemp)"
   set +e
   export DOKKU_UID=$(id -u)
   export DOKKU_GID=$(id -g)
@@ -115,9 +142,9 @@ fn-letsencrypt-acme-revoke() {
     -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
     "${docker_options_argv[@]}" \
     "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
-    "${config[@]}" revoke | sed "s/^/       /"
+    "${config[@]}" revoke 2>&1 | tee "$lego_log" | sed "s/^/       /"
 
-  local exit_code=$?
+  local exit_code=${PIPESTATUS[0]}
   set -e
 
   # handle return codes
@@ -126,9 +153,15 @@ fn-letsencrypt-acme-revoke() {
     dokku_log_info1 "Certificate revoked successfully."
   else
     # error - don't try to link certificates
-    dokku_log_info1 "Certificate revocation failed (code $simple_result)!"
+    if fn-letsencrypt-detect-rate-limit "$lego_log"; then
+      fn-letsencrypt-log-rate-limit "$APP"
+    fi
+    rm -f "$lego_log"
+    dokku_log_info1 "Certificate revocation failed (code $exit_code)!"
     return
   fi
+
+  rm -f "$lego_log"
 
   local domain="$(fn-letsencrypt-app-domains "$APP" | xargs | awk '{print $1}')"
 

--- a/tests/letsencrypt_rate_limit.bats
+++ b/tests/letsencrypt_rate_limit.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+# Unit tests for fn-letsencrypt-detect-rate-limit.
+#
+# The function is the seam the integration code uses to decide whether to
+# surface the dedicated "Let's Encrypt rate-limited this request" warning
+# after a failed lego run. Pebble does not simulate ACME rate-limit
+# responses, so the integration test stack cannot exercise the real
+# detection path end-to-end. Instead we extract the function from
+# internal-functions and feed it canonical lego/ACME error fixtures.
+
+INTERNAL_FUNCTIONS_PATH="/var/lib/dokku/plugins/enabled/letsencrypt/internal-functions"
+
+setup() {
+  if [ ! -f "$INTERNAL_FUNCTIONS_PATH" ]; then
+    skip "letsencrypt plugin not installed at $INTERNAL_FUNCTIONS_PATH"
+  fi
+
+  LOG_FIXTURE="$(mktemp)"
+
+  # Source only the detector function so we don't need the rest of the
+  # plugin's runtime context (PLUGIN_CORE_AVAILABLE_PATH, etc.).
+  # shellcheck source=/dev/null
+  source <($SUDO awk '/^fn-letsencrypt-detect-rate-limit\(\)/,/^}/' "$INTERNAL_FUNCTIONS_PATH")
+}
+
+teardown() {
+  rm -f "$LOG_FIXTURE"
+}
+
+@test "fn-letsencrypt-detect-rate-limit matches the rateLimited URN" {
+  cat >"$LOG_FIXTURE" <<'EOF'
+2025/05/12 12:00:00 [INFO] [example.com] acme: Obtaining bundled SAN certificate
+acme: error: 429 :: POST :: https://acme-v02.api.letsencrypt.org/acme/new-order :: urn:ietf:params:acme:error:rateLimited :: Error creating new order
+EOF
+
+  run fn-letsencrypt-detect-rate-limit "$LOG_FIXTURE"
+  [ "$status" -eq 0 ]
+}
+
+@test "fn-letsencrypt-detect-rate-limit matches '429 Too Many Requests'" {
+  cat >"$LOG_FIXTURE" <<'EOF'
+2025/05/12 12:00:00 [INFO] acme: Registering account
+HTTP 429 Too Many Requests returned by the ACME server
+EOF
+
+  run fn-letsencrypt-detect-rate-limit "$LOG_FIXTURE"
+  [ "$status" -eq 0 ]
+}
+
+@test "fn-letsencrypt-detect-rate-limit matches 'too many certificates already issued'" {
+  cat >"$LOG_FIXTURE" <<'EOF'
+too many certificates already issued for "example.com": see https://letsencrypt.org/docs/rate-limits/
+EOF
+
+  run fn-letsencrypt-detect-rate-limit "$LOG_FIXTURE"
+  [ "$status" -eq 0 ]
+}
+
+@test "fn-letsencrypt-detect-rate-limit matches 'too many failed authorizations'" {
+  cat >"$LOG_FIXTURE" <<'EOF'
+acme: error: 429 :: too many failed authorizations recently
+EOF
+
+  run fn-letsencrypt-detect-rate-limit "$LOG_FIXTURE"
+  [ "$status" -eq 0 ]
+}
+
+@test "fn-letsencrypt-detect-rate-limit ignores ordinary errors" {
+  cat >"$LOG_FIXTURE" <<'EOF'
+2025/05/12 12:00:00 [INFO] [example.com] acme: Trying to solve HTTP-01
+2025/05/12 12:00:05 [ERROR] [example.com] acme: error presenting token: connection refused
+EOF
+
+  run fn-letsencrypt-detect-rate-limit "$LOG_FIXTURE"
+  [ "$status" -ne 0 ]
+}
+
+@test "fn-letsencrypt-detect-rate-limit returns non-zero when the log path is missing" {
+  run fn-letsencrypt-detect-rate-limit "/tmp/does-not-exist-$$"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
The plugin previously buried Let's Encrypt rate-limit responses inside the unindented lego container output and exited with a generic "Certificate retrieval failed!" line. The captured output is now scanned for the canonical `urn:ietf:params:acme:error:rateLimited` URN, an HTTP `429 Too Many Requests` status, and the common lego "too many certificates" / "too many failed authorizations" phrasings, and a dedicated warning pointing at the [Let's Encrypt rate-limit documentation](https://letsencrypt.org/docs/rate-limits/) is emitted before the failure line.

Closes GH-356.