### PR TITLE
refactor: call fn-letsencrypt-enable from auto-renew

### DIFF
--- a/command-functions
+++ b/command-functions
@@ -45,7 +45,7 @@ cmd-letsencrypt-auto-renew() {
     while IFS=$'\t' read -r -a appExpiry; do
       if [[ ${appExpiry[4]} -lt 0 ]]; then
         dokku_log_info1 "${appExpiry[0]} needs renewal"
-        if ! dokku letsencrypt:enable "${appExpiry[0]}"; then
+        if ! (fn-letsencrypt-enable "${appExpiry[0]}"); then
           EXIT_CODE=1
         fi
       else
@@ -74,7 +74,7 @@ cmd-letsencrypt-auto-renew() {
 
     if [[ $time_to_renewal -lt 0 ]]; then
       dokku_log_info2 "Auto-renew ${APP}..."
-      dokku letsencrypt:enable "$APP"
+      fn-letsencrypt-enable "$APP"
     else
       days_left=$(fn-letsencrypt-format-timediff $time_to_renewal)
       dokku_log_verbose "$APP still has $days_left left before renewal"


### PR DESCRIPTION
Replaces the two `dokku letsencrypt:enable` sub-process invocations inside `cmd-letsencrypt-auto-renew` with direct calls to `fn-letsencrypt-enable`. The batch path runs in a sub-shell so a single app's `dokku_log_fail` no longer aborts the whole renewal sweep.

The three remaining `dokku certs:add` / `dokku certs:remove` call sites in `internal-functions` cannot be converted today because the certs plugin in dokku core does not expose sourceable functions or plugin triggers for those operations; tracked upstream in dokku/dokku#8623. The `cron-job` script and `cron-entries` trigger keep invoking `dokku letsencrypt:auto-renew` because cron runs them in a fresh shell that needs the CLI wrapper to bootstrap the plugin env.