### PR TITLE
feat: share acme account across apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ While playing around with this plugin, you might want to switch to the let's enc
 
 When the ACME server returns a rate-limit response, `letsencrypt:enable` exits non-zero and prints a dedicated warning that points at the [Let's Encrypt rate-limits documentation](https://letsencrypt.org/docs/rate-limits/) and suggests switching to the staging server while iterating. The full lego output is still printed above the warning, so the specific limit that was hit (for example "too many certificates already issued" or "too many failed authorizations") remains visible.
 
+### Shared ACME account
+
+To stay clear of the [new accounts per IP](https://letsencrypt.org/docs/rate-limits/) limit (10 per 3 hours), the plugin stores a single ACME account in `${DOKKU_LIB_ROOT}/data/letsencrypt/accounts` and mounts it into every `lego` invocation. Apps sharing the same `email` and `server` reuse one account regardless of how many apps are enabled, matching Let's Encrypt's [recommendation](https://letsencrypt.org/docs/integration-guide/#one-account-or-many) for hosting providers. Apps configured with a distinct `email` or `server` get their own entry under the shared directory, keyed by `(server, email)`.
+
+When upgrading from a previous version of this plugin, the first `letsencrypt:enable` after the upgrade registers exactly one new account in the shared directory. Existing per-app account material under `$DOKKU_ROOT/<app>/letsencrypt/certs/<hash>/accounts/` is left in place so that `letsencrypt:revoke` for certificates issued before the upgrade can still find the original account.
+
 ## Generating a Cert for multiple domains
 
 Your [default dokku app](https://dokku.com/docs/networking/proxies/nginx/?h=default+site#default-site) is accessible under the root domain too. So if you have an application `00-default` that is running under `00-default.mydomain.com` it is accessible under `mydomain.com` too. Now if you enable letsencrypt for your `00-default` application, it is not accessible anymore on `mydomain.com`. You can add the root domain to your dokku domains by typing:

--- a/install
+++ b/install
@@ -98,6 +98,8 @@ plugin-install() {
   pull-docker-image "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}"
 
   mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt"
+  mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
+  chmod 0700 "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
   chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/letsencrypt"
   fn-plugin-property-setup "letsencrypt"
   fn-letsencrypt-migrate-properties

--- a/internal-functions
+++ b/internal-functions
@@ -27,6 +27,53 @@ fn-letsencrypt-log-rate-limit() {
   dokku_log_warn "Use 'dokku letsencrypt:set ${APP:-<app>} server staging' while iterating to avoid the production limits."
 }
 
+fn-letsencrypt-shared-accounts-dir() {
+  declare desc="dokku-host path to the shared lego accounts directory"
+  echo "$DOKKU_LIB_ROOT/data/letsencrypt/accounts"
+}
+
+fn-letsencrypt-shared-accounts-host-dir() {
+  declare desc="docker-host path to the shared lego accounts directory"
+  echo "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/accounts"
+}
+
+fn-letsencrypt-ensure-shared-accounts-dir() {
+  declare desc="create the shared lego accounts directory with strict permissions"
+  local accounts_dir
+  accounts_dir="$(fn-letsencrypt-shared-accounts-dir)"
+  mkdir -p "$accounts_dir"
+  # account keys live here; restrict to the dokku user.
+  chmod 0700 "$accounts_dir"
+}
+
+fn-letsencrypt-account-server-dir() {
+  declare desc="lego-style directory name derived from the configured ACME server URL"
+  declare APP="$1"
+  local server host
+
+  server="$(fn-letsencrypt-computed-server "$APP")"
+  host="${server#http://}"
+  host="${host#https://}"
+  host="${host%%/*}"
+  # lego stores accounts under a host segment with ':' replaced by '_'
+  host="${host//:/_}"
+  echo "$host"
+}
+
+fn-letsencrypt-shared-account-exists() {
+  declare desc="return 0 when the shared accounts dir holds an account for this app's (server, email)"
+  declare APP="$1"
+  local server_dir email accounts_dir
+
+  server_dir="$(fn-letsencrypt-account-server-dir "$APP")"
+  email="$(fn-letsencrypt-computed-email "$APP")"
+  if [[ -z "$server_dir" ]] || [[ -z "$email" ]]; then
+    return 1
+  fi
+  accounts_dir="$(fn-letsencrypt-shared-accounts-dir)"
+  [[ -f "$accounts_dir/$server_dir/$email/account.json" ]]
+}
+
 fn-letsencrypt-acme-execute-challenge() {
   declare desc="perform actual ACME validation procedure"
   declare APP="$1"
@@ -59,20 +106,26 @@ fn-letsencrypt-acme-execute-challenge() {
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
-  local lego_log
+  local lego_log shared_accounts_lock
   lego_log="$(mktemp)"
   set +e
   export DOKKU_UID=$(id -u)
   export DOKKU_GID=$(id -g)
   mkdir -p "$DOKKU_LIB_ROOT/data/letsencrypt/$APP"
-  docker run --rm \
-    --env-file "$container_config_dir/docker.env" \
-    --user $DOKKU_UID:$DOKKU_GID \
-    -v "$host_config_dir:/certs" \
-    -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
-    "${docker_options_argv[@]}" \
-    "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
-    "${config[@]}" run 2>&1 | tee "$lego_log" | sed "s/^/       /"
+  fn-letsencrypt-ensure-shared-accounts-dir
+  shared_accounts_lock="$(fn-letsencrypt-shared-accounts-dir)/.lock"
+  {
+    flock -x 9
+    docker run --rm \
+      --env-file "$container_config_dir/docker.env" \
+      --user $DOKKU_UID:$DOKKU_GID \
+      -v "$host_config_dir:/certs" \
+      -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
+      -v "$(fn-letsencrypt-shared-accounts-host-dir):/certs/accounts" \
+      "${docker_options_argv[@]}" \
+      "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
+      "${config[@]}" run 2>&1
+  } 9>"$shared_accounts_lock" | tee "$lego_log" | sed "s/^/       /"
 
   local exit_code=${PIPESTATUS[0]}
   set -e
@@ -128,21 +181,36 @@ fn-letsencrypt-acme-revoke() {
 
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
-  local lego_log
+  local lego_log shared_accounts_lock
   lego_log="$(mktemp)"
   set +e
   export DOKKU_UID=$(id -u)
   export DOKKU_GID=$(id -g)
   mkdir -p "$DOKKU_LIB_ROOT/data/letsencrypt/$APP"
-  docker run --rm \
-    --env-file "$container_config_dir/docker.env" \
-    --user $DOKKU_UID:$DOKKU_GID \
-    -p "$acme_port:$acme_port" \
-    -v "$host_config_dir:/certs" \
-    -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
-    "${docker_options_argv[@]}" \
-    "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
-    "${config[@]}" revoke 2>&1 | tee "$lego_log" | sed "s/^/       /"
+  fn-letsencrypt-ensure-shared-accounts-dir
+  shared_accounts_lock="$(fn-letsencrypt-shared-accounts-dir)/.lock"
+
+  # Only overlay the shared accounts dir when it holds the matching
+  # (server, email) account; otherwise fall back to the per-app account
+  # so revocation of certs issued before the shared-account change still works.
+  local account_volume_args=()
+  if fn-letsencrypt-shared-account-exists "$APP"; then
+    account_volume_args=(-v "$(fn-letsencrypt-shared-accounts-host-dir):/certs/accounts")
+  fi
+
+  {
+    flock -x 9
+    docker run --rm \
+      --env-file "$container_config_dir/docker.env" \
+      --user $DOKKU_UID:$DOKKU_GID \
+      -p "$acme_port:$acme_port" \
+      -v "$host_config_dir:/certs" \
+      -v "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/$APP:/webroot" \
+      "${account_volume_args[@]}" \
+      "${docker_options_argv[@]}" \
+      "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}" \
+      "${config[@]}" revoke 2>&1
+  } 9>"$shared_accounts_lock" | tee "$lego_log" | sed "s/^/       /"
 
   local exit_code=${PIPESTATUS[0]}
   set -e
@@ -355,7 +423,6 @@ fn-letsencrypt-configure-and-get-dir() {
 
   local app_root="$DOKKU_ROOT/$APP"
   local le_root="$app_root/letsencrypt"
-  mkdir -p "$DOKKU_ROOT/$APP/letsencrypt/account"
 
   for domain in $(fn-letsencrypt-app-domains "$APP"); do
     dokku_log_verbose " - Domain '$domain'" >&2

--- a/tests/letsencrypt_shared_account.bats
+++ b/tests/letsencrypt_shared_account.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  APP1="$(new_app_name)-a"
+  APP2="$(new_app_name)-b"
+  DOMAIN1="${APP1}.${TEST_DOMAIN_BASE}"
+  DOMAIN2="${APP2}.${TEST_DOMAIN_BASE}"
+  create_app "$APP1"
+  create_app "$APP2"
+  set_domain "$APP1" "$DOMAIN1"
+  set_domain "$APP2" "$DOMAIN2"
+  register_a_record "$DOMAIN1"
+  register_a_record "$DOMAIN2"
+  SERVER="$(dokku letsencrypt:report "$APP1" --letsencrypt-computed-server)"
+  EMAIL="$(dokku letsencrypt:report "$APP1" --letsencrypt-computed-email)"
+  ACCOUNT_DIR="$(shared_account_dir_for "$SERVER" "$EMAIL")"
+}
+
+teardown() {
+  clear_a_record "$DOMAIN1"
+  clear_a_record "$DOMAIN2"
+  cleanup_app "$APP1"
+  cleanup_app "$APP2"
+}
+
+@test "two apps share a single ACME account via the shared accounts dir" {
+  run dokku letsencrypt:enable "$APP1"
+  [ "$status" -eq 0 ]
+
+  $SUDO test -f "$ACCOUNT_DIR/account.json" || {
+    echo "expected account.json at $ACCOUNT_DIR" >&2
+    $SUDO ls -laR "$(shared_accounts_dir)" >&2 || true
+    return 1
+  }
+  $SUDO test -d "$ACCOUNT_DIR/keys"
+
+  # capture the bytes of account.json and the entire keys/ tree
+  account_before="$($SUDO cat "$ACCOUNT_DIR/account.json")"
+  keys_before="$($SUDO tar -cf - -C "$ACCOUNT_DIR" keys | sha256sum | awk '{print $1}')"
+
+  run dokku letsencrypt:enable "$APP2"
+  [ "$status" -eq 0 ]
+
+  account_after="$($SUDO cat "$ACCOUNT_DIR/account.json")"
+  keys_after="$($SUDO tar -cf - -C "$ACCOUNT_DIR" keys | sha256sum | awk '{print $1}')"
+
+  # second enable must reuse the same account material, not register again
+  [ "$account_before" = "$account_after" ]
+  [ "$keys_before" = "$keys_after" ]
+
+  # exactly one email directory under the server segment
+  server_seg="$(shared_account_server_segment "$SERVER")"
+  count="$($SUDO find "$(shared_accounts_dir)/${server_seg}" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  [ "$count" = "1" ]
+}
+
+@test "shared accounts directory is created with 0700 mode" {
+  dokku letsencrypt:enable "$APP1"
+
+  mode="$($SUDO stat -c '%a' "$(shared_accounts_dir)" 2>/dev/null || $SUDO stat -f '%Lp' "$(shared_accounts_dir)")"
+  [ "$mode" = "700" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -127,3 +127,25 @@ config_hash_dirs() {
   $SUDO test -d "$base" || return 0
   $SUDO find "$base" -mindepth 1 -maxdepth 1 -type d -print
 }
+
+shared_accounts_dir() {
+  echo "/var/lib/dokku/data/letsencrypt/accounts"
+}
+
+# lego stores accounts under <accounts>/<host>/<email>/, with ':' in the host
+# segment replaced by '_'. This mirrors the bash logic in
+# fn-letsencrypt-account-server-dir.
+shared_account_server_segment() {
+  local server="$1"
+  server="${server#http://}"
+  server="${server#https://}"
+  server="${server%%/*}"
+  echo "${server//:/_}"
+}
+
+shared_account_dir_for() {
+  local server="$1" email="$2"
+  local server_seg
+  server_seg="$(shared_account_server_segment "$server")"
+  echo "$(shared_accounts_dir)/${server_seg}/${email}"
+}


### PR DESCRIPTION
## Summary

The lego accounts directory is now mounted from a shared host path so apps configured with the same `email` and `server` reuse a single ACME account instead of each registering its own. This sidesteps the Let's Encrypt 10-new-accounts-per-IP-per-3-hours limit for hosts adding HTTPS to many apps and matches Let's Encrypt's recommended one-account-per-host integration pattern. Concurrent lego invocations are serialized with `flock` against a lockfile in the shared directory because lego itself does not lock its account store. `letsencrypt:revoke` falls back to the per-app account when the shared directory has no matching entry, so certificates issued before the upgrade can still be revoked.

Closes #158