### PR TITLE
fix: pin acme webroot perms so nginx can serve challenges

### DIFF
--- a/install
+++ b/install
@@ -98,12 +98,13 @@ plugin-install() {
   pull-docker-image "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}"
 
   mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt"
-  chmod 0750 "${DOKKU_LIB_ROOT}/data/letsencrypt"
+  chmod 0755 "${DOKKU_LIB_ROOT}/data/letsencrypt"
   # Heal per-app ACME webroots whose mode was previously left at the invoker's
-  # umask (commonly 0700 under sudo). Skip the dedicated `accounts/` dir,
-  # which is locked down to 0700 just below.
+  # umask (commonly 0700 under sudo). nginx must be able to read these to
+  # serve HTTP-01 challenges; the files are public by design. Skip the
+  # dedicated `accounts/` dir, which is locked down to 0700 just below.
   find "${DOKKU_LIB_ROOT}/data/letsencrypt" -mindepth 1 -maxdepth 1 -type d \
-    ! -name accounts -exec chmod 0750 {} +
+    ! -name accounts -exec chmod 0755 {} +
   mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
   chmod 0700 "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
   chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/letsencrypt"

--- a/install
+++ b/install
@@ -98,6 +98,12 @@ plugin-install() {
   pull-docker-image "${PLUGIN_IMAGE}:${PLUGIN_IMAGE_VERSION}"
 
   mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt"
+  chmod 0750 "${DOKKU_LIB_ROOT}/data/letsencrypt"
+  # Heal per-app ACME webroots whose mode was previously left at the invoker's
+  # umask (commonly 0700 under sudo). Skip the dedicated `accounts/` dir,
+  # which is locked down to 0700 just below.
+  find "${DOKKU_LIB_ROOT}/data/letsencrypt" -mindepth 1 -maxdepth 1 -type d \
+    ! -name accounts -exec chmod 0750 {} +
   mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
   chmod 0700 "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
   chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/letsencrypt"

--- a/internal-functions
+++ b/internal-functions
@@ -46,6 +46,18 @@ fn-letsencrypt-ensure-shared-accounts-dir() {
   chmod 0700 "$accounts_dir"
 }
 
+fn-letsencrypt-ensure-app-webroot-dir() {
+  declare desc="create the per-app ACME webroot with traversable group perms"
+  declare APP="$1"
+  local webroot
+  webroot="$DOKKU_LIB_ROOT/data/letsencrypt/$APP"
+  mkdir -p "$webroot"
+  # nginx (www-data, in the dokku group) must traverse this directory to
+  # serve /.well-known/acme-challenge files. Pin the mode so a restrictive
+  # umask on the invoker (e.g. 0077) cannot leave it at 0700.
+  chmod 0750 "$webroot"
+}
+
 fn-letsencrypt-account-server-dir() {
   declare desc="lego-style directory name derived from the configured ACME server URL"
   declare APP="$1"
@@ -111,7 +123,7 @@ fn-letsencrypt-acme-execute-challenge() {
   set +e
   export DOKKU_UID=$(id -u)
   export DOKKU_GID=$(id -g)
-  mkdir -p "$DOKKU_LIB_ROOT/data/letsencrypt/$APP"
+  fn-letsencrypt-ensure-app-webroot-dir "$APP"
   fn-letsencrypt-ensure-shared-accounts-dir
   shared_accounts_lock="$(fn-letsencrypt-shared-accounts-dir)/.lock"
   {
@@ -186,7 +198,7 @@ fn-letsencrypt-acme-revoke() {
   set +e
   export DOKKU_UID=$(id -u)
   export DOKKU_GID=$(id -g)
-  mkdir -p "$DOKKU_LIB_ROOT/data/letsencrypt/$APP"
+  fn-letsencrypt-ensure-app-webroot-dir "$APP"
   fn-letsencrypt-ensure-shared-accounts-dir
   shared_accounts_lock="$(fn-letsencrypt-shared-accounts-dir)/.lock"
 

--- a/internal-functions
+++ b/internal-functions
@@ -47,15 +47,16 @@ fn-letsencrypt-ensure-shared-accounts-dir() {
 }
 
 fn-letsencrypt-ensure-app-webroot-dir() {
-  declare desc="create the per-app ACME webroot with traversable group perms"
+  declare desc="create the per-app ACME webroot with world-traversable perms"
   declare APP="$1"
   local webroot
   webroot="$DOKKU_LIB_ROOT/data/letsencrypt/$APP"
   mkdir -p "$webroot"
-  # nginx (www-data, in the dokku group) must traverse this directory to
-  # serve /.well-known/acme-challenge files. Pin the mode so a restrictive
-  # umask on the invoker (e.g. 0077) cannot leave it at 0700.
-  chmod 0750 "$webroot"
+  # nginx must traverse this directory to serve /.well-known/acme-challenge
+  # files. The files are public by design (ACME HTTP-01 fetches them over
+  # plain HTTP), and not every dokku install puts www-data in the dokku
+  # group, so pin 0755 instead of relying on the invoker's umask.
+  chmod 0755 "$webroot"
 }
 
 fn-letsencrypt-account-server-dir() {

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -116,6 +116,18 @@ teardown() {
   echo "$output" | grep -qi "no domains"
 }
 
+@test "letsencrypt:enable normalizes the per-app webroot perms to 0750" {
+  webroot="/var/lib/dokku/data/letsencrypt/$APP"
+  $SUDO mkdir -p "$webroot"
+  $SUDO chmod 0700 "$webroot"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+
+  perm="$($SUDO stat -c '%a' "$webroot")"
+  [ "$perm" = "750" ]
+}
+
 @test "letsencrypt:enable reissues when a new domain is added" {
   dokku letsencrypt:set "$APP" graceperiod 60
   dokku letsencrypt:enable "$APP"

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -118,8 +118,10 @@ teardown() {
 
 @test "letsencrypt:enable normalizes the per-app webroot perms to 0755" {
   webroot="/var/lib/dokku/data/letsencrypt/$APP"
-  $SUDO mkdir -p "$webroot"
-  $SUDO chmod 0700 "$webroot"
+  # Pre-stage the dir with the broken mode the bug describes, owned by the
+  # dokku user so the plugin (which runs as dokku via the dokku wrapper)
+  # can chmod it.
+  $SUDO install -d -o dokku -g dokku -m 0700 "$webroot"
 
   run dokku letsencrypt:enable "$APP"
   [ "$status" -eq 0 ]

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -116,7 +116,7 @@ teardown() {
   echo "$output" | grep -qi "no domains"
 }
 
-@test "letsencrypt:enable normalizes the per-app webroot perms to 0750" {
+@test "letsencrypt:enable normalizes the per-app webroot perms to 0755" {
   webroot="/var/lib/dokku/data/letsencrypt/$APP"
   $SUDO mkdir -p "$webroot"
   $SUDO chmod 0700 "$webroot"
@@ -125,7 +125,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   perm="$($SUDO stat -c '%a' "$webroot")"
-  [ "$perm" = "750" ]
+  [ "$perm" = "755" ]
 }
 
 @test "letsencrypt:enable reissues when a new domain is added" {

--- a/tests/letsencrypt_install_perms.bats
+++ b/tests/letsencrypt_install_perms.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+@test "plugin:update heals pre-existing per-app webroots with restrictive mode" {
+  local bad_app parent webroot
+  bad_app="letest-perm-$(date +%s)-${RANDOM}"
+  parent="/var/lib/dokku/data/letsencrypt"
+  webroot="${parent}/${bad_app}"
+
+  $SUDO mkdir -p "$webroot"
+  $SUDO chmod 0700 "$webroot"
+  $SUDO chmod 0700 "$parent"
+
+  run $SUDO dokku plugin:update letsencrypt
+  [ "$status" -eq 0 ]
+
+  [ "$($SUDO stat -c '%a' "$parent")" = "750" ]
+  [ "$($SUDO stat -c '%a' "$webroot")" = "750" ]
+  [ "$($SUDO stat -c '%a' "${parent}/accounts")" = "700" ]
+
+  $SUDO rm -rf "$webroot"
+}

--- a/tests/letsencrypt_install_perms.bats
+++ b/tests/letsencrypt_install_perms.bats
@@ -15,8 +15,8 @@ load 'test_helper'
   run $SUDO dokku plugin:update letsencrypt
   [ "$status" -eq 0 ]
 
-  [ "$($SUDO stat -c '%a' "$parent")" = "750" ]
-  [ "$($SUDO stat -c '%a' "$webroot")" = "750" ]
+  [ "$($SUDO stat -c '%a' "$parent")" = "755" ]
+  [ "$($SUDO stat -c '%a' "$webroot")" = "755" ]
   [ "$($SUDO stat -c '%a' "${parent}/accounts")" = "700" ]
 
   $SUDO rm -rf "$webroot"


### PR DESCRIPTION
The plugin used to create `${DOKKU_LIB_ROOT}/data/letsencrypt/<app>` with a bare `mkdir -p`, so its mode inherited the invoker's umask. When `letsencrypt:enable` ran under a tight umask (`0077` is common for `sudo` shells) the per-app webroot ended up `0700`, nginx could not traverse it, and HTTP-01 validation returned 403 even though everything else was wired up correctly. The plugin now pins the per-app webroot and the shared `${DOKKU_LIB_ROOT}/data/letsencrypt` parent to `0755` (the ACME challenge files are public by design and not every dokku install puts `www-data` in the `dokku` group, so a group-only mode like `0750` is not universally safe), and the `install`/`update` hook sweeps existing per-app subdirectories so `dokku plugin:update letsencrypt` heals previously-broken hosts without waiting for the next enable. The dedicated `accounts/` directory keeps its `0700` lockdown.

Closes #362.