### PR TITLE
feat: auto-inject http:80 port mapping when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ When securing Dockerfile and Image-based deploys with dokku-letsencrypt, be awar
 
 For Dockerfile deploys - as well as those via `git:from-image` - Dokku will determine which ports a container exposes (using `EXPOSE`) and will proxy them on the same port numbers on the host. If the Dockerfile exposes another port than 443, then HTTPS port 443 **needs to be manually configured** using the `dokku ports:*` commands in order for certificate validation and browsing to the app via HTTPS to work.
 
+The HTTP-01 challenge used by Let's Encrypt also needs the app to be reachable on port 80. When `letsencrypt:enable` runs and the app's proxy port-map has no `http:80:*` entry, the plugin will inject one automatically using the container port from the first existing `http:*:*` (or `https:*:*`) mapping, so the ACME challenge can be served from nginx. The new mapping is persisted so subsequent renewals do not need to re-add it. If no `http` or `https` mapping exists at all, `letsencrypt:enable` exits with an error pointing to `dokku ports:add` instead of issuing a request that would fail at the ACME server. DNS-01 deployments skip this check because they do not depend on a port 80 listener.
+
 A full workflow for creating a new Dockerfile/Image-based deployment (assuming the app is listening/exposed on port 5555) with `dokku-letsencrypt` would be:
 
 1. Create a new app `myapp` in dokku and push to the `dokku@myhost.com` remote.
@@ -185,7 +187,7 @@ After these steps, the output of `dokku ports:report myapp` should look like thi
 
 ```
 =====> myapp ports information
-       Ports map:                     https:443:5555
+       Ports map:                     http:80:5555 https:443:5555
        Ports map detected:            https:5555:5555
 ```
 

--- a/internal-functions
+++ b/internal-functions
@@ -289,6 +289,51 @@ fn-letsencrypt-acme-proxy-enable() {
   restart_nginx | sed "s/^/       /"
 }
 
+fn-letsencrypt-ensure-http-port() {
+  declare desc="ensure the app has an http:80 proxy mapping so nginx can serve the HTTP-01 challenge"
+  declare APP="$1"
+  local port_map line container_port
+
+  # HTTP-01 is the only challenge type that needs a listener on port 80; the
+  # DNS-01 flow never hits nginx.
+  if [[ -n "$(fn-letsencrypt-computed-dns-provider "$APP")" ]]; then
+    return 0
+  fi
+
+  port_map="$(plugn trigger ports-get "$APP" 2>/dev/null || true)"
+
+  while IFS= read -r line; do
+    [[ "$line" == http:80:* ]] && return 0
+  done <<<"$port_map"
+
+  container_port=""
+  while IFS= read -r line; do
+    if [[ "$line" == http:*:* ]]; then
+      container_port="${line##*:}"
+      break
+    fi
+  done <<<"$port_map"
+
+  if [[ -z "$container_port" ]]; then
+    while IFS= read -r line; do
+      if [[ "$line" == https:*:* ]]; then
+        container_port="${line##*:}"
+        break
+      fi
+    done <<<"$port_map"
+  fi
+
+  if [[ -z "$container_port" ]]; then
+    dokku_log_warn "Cannot enable letsencrypt for $APP: no http or https proxy port mapping was found."
+    dokku_log_warn "  letsencrypt needs an http listener on port 80 to serve the ACME HTTP-01 challenge."
+    dokku_log_warn "  Add one with: dokku ports:add $APP http:80:<container-port>"
+    return 1
+  fi
+
+  dokku_log_info1 "Adding http:80:${container_port} port mapping to ${APP} for ACME HTTP-01 challenge..."
+  dokku ports:add "$APP" "http:80:${container_port}" | sed "s/^/       /"
+}
+
 fn-letsencrypt-computed-dns-provider() {
   declare desc="get configured dns provider, with 'none' as an explicit opt-out sentinel"
   declare APP="$1"
@@ -612,6 +657,7 @@ fn-letsencrypt-enable() {
     return 0
   fi
 
+  fn-letsencrypt-ensure-http-port "$APP"
   fn-letsencrypt-acme-proxy-enable "$APP"
   fn-letsencrypt-acme-execute-challenge "$APP" || EXIT_CODE=$? # remove ACME proxy even if this fails
   fn-letsencrypt-acme-proxy-disable "$APP"

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -130,6 +130,44 @@ teardown() {
   [ "$perm" = "755" ]
 }
 
+@test "letsencrypt:enable auto-injects http:80 when only a non-80 http mapping exists" {
+  dokku ports:set "$APP" http:8080:8080
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "Adding http:80:8080 port mapping"
+
+  assert_cert_exists "$APP"
+  assert_cert_issued_by_pebble "$APP"
+
+  run dokku ports:report "$APP" --ports-map
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "http:80:8080"
+  echo "$output" | grep -qF "http:8080:8080"
+}
+
+@test "letsencrypt:enable leaves the port map untouched when http:80 is already mapped" {
+  dokku ports:set "$APP" http:80:5000
+
+  before="$(dokku ports:report "$APP" --ports-map)"
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -qi "Adding http:80"
+
+  after="$(dokku ports:report "$APP" --ports-map)"
+  [ "$before" = "$after" ]
+}
+
+@test "letsencrypt:enable fails with a helpful error when no http or https mapping exists" {
+  dokku ports:set "$APP" tcp:2222:2222
+
+  run dokku letsencrypt:enable "$APP"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "no http or https proxy port mapping"
+  echo "$output" | grep -qi "dokku ports:add"
+}
+
 @test "letsencrypt:enable reissues when a new domain is added" {
   dokku letsencrypt:set "$APP" graceperiod 60
   dokku letsencrypt:enable "$APP"

--- a/tests/letsencrypt_enable_http01.bats
+++ b/tests/letsencrypt_enable_http01.bats
@@ -146,17 +146,18 @@ teardown() {
   echo "$output" | grep -qF "http:8080:8080"
 }
 
-@test "letsencrypt:enable leaves the port map untouched when http:80 is already mapped" {
+@test "letsencrypt:enable does not re-add http:80 when it is already mapped" {
   dokku ports:set "$APP" http:80:5000
-
-  before="$(dokku ports:report "$APP" --ports-map)"
 
   run dokku letsencrypt:enable "$APP"
   [ "$status" -eq 0 ]
   ! echo "$output" | grep -qi "Adding http:80"
 
-  after="$(dokku ports:report "$APP" --ports-map)"
-  [ "$before" = "$after" ]
+  run dokku ports:report "$APP" --ports-map
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "http:80:5000"
+  # Exactly one http:80 entry — the cert install adds https:443 but must not duplicate http:80
+  [ "$(echo "$output" | tr ' ' '\n' | grep -c '^http:80:')" -eq 1 ]
 }
 
 @test "letsencrypt:enable fails with a helpful error when no http or https mapping exists" {


### PR DESCRIPTION
## Summary

When `letsencrypt:enable` runs against an app whose proxy port-map has no `http:80:*` entry, the HTTP-01 challenge fails because nginx is not listening on port 80 for that vhost. This is routine on Dockerfile and Docker-image workflows where Dokku auto-detects the port the container `EXPOSE`s and writes a map like `http:8080:8080`, leaving the ACME proxy snippet unreachable. Users hit a confusing "CA marked some of the authorizations as invalid" error and only learn from the issue tracker that the fix is to run `dokku ports:add <app> http:80:<container-port>` themselves.

The plugin now reads the current proxy port-map via the `ports-get` trigger and, when no `http:80:*` mapping exists, injects one using the container port from the first existing `http:*:*` or `https:*:*` mapping. The new mapping is persisted so subsequent renewals do not need to re-add it. DNS-01 deployments skip the check because they do not depend on a port 80 listener, and apps with no `http` or `https` mapping at all now fail fast with a message pointing at `dokku ports:add` rather than burning an ACME request that would fail at the CA.

Closes #196.