### PR TITLE
feat: surface dns-provider-* properties in letsencrypt:report

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ dokku letsencrypt:report myapp --letsencrypt-email
 
 Combining `--format json` with a single property flag is rejected.
 
+Any `dns-provider-*` properties set globally or for the app appear in the report alongside the fixed fields. For each set property, the report emits the scopes that actually have a value: a `--letsencrypt-dns-provider-<KEY>` row when set on the app, a `--letsencrypt-global-dns-provider-<KEY>` row when set globally, and a `--letsencrypt-computed-dns-provider-<KEY>` row that resolves to the app value (falling back to the global value). Querying an unset scope with the info-flag form is rejected as an invalid flag.
+
+The top-level `dokku report <app>` command aggregates output from every plugin and is commonly used in support and diagnostic contexts. When the letsencrypt section is rendered through that aggregate command, every `dns-provider-*` credential value is redacted to `****` to avoid leaking DNS provider API keys, tokens, or `_FILE` paths into shared output. The provider *name* (`dns-provider`, `global-dns-provider`, `computed-dns-provider`) and every other property (`email`, `server`, `graceperiod`, `lego-args`, `lego-docker-options`) remain unredacted. `dokku letsencrypt:report` is unaffected and continues to show raw values, so operators can verify what they have configured.
+
 ## Redirecting from HTTP to HTTPS
 
 Dokku's default nginx template will automatically redirect HTTP requests to HTTPS when a certificate is present.

--- a/command-functions
+++ b/command-functions
@@ -284,6 +284,8 @@ cmd-letsencrypt-report-single() {
     "--letsencrypt-server: $(fn-letsencrypt-server "$APP")"
   )
 
+  fn-letsencrypt-report-add-dns-provider-keys flag_map "$APP"
+
   if [[ "$APP" == "--global" ]]; then
     fn-letsencrypt-report-filter-global flag_map
   fi

--- a/internal-functions
+++ b/internal-functions
@@ -966,3 +966,66 @@ fn-letsencrypt-report-emit-json() {
   done
   echo "$json_output"
 }
+
+fn-letsencrypt-report-add-dns-provider-keys() {
+  declare desc="append per-key dns-provider-* rows to flag_map (computed/global/app), redacting values when LETSENCRYPT_REPORT_SANITIZE=true"
+  declare flag_map_name="$1" APP="$2"
+  local -n flag_map_ref="$flag_map_name"
+
+  local sanitize="${LETSENCRYPT_REPORT_SANITIZE:-false}"
+  local line key value
+  declare -A global_values=()
+  declare -A app_values=()
+  declare -A keyset=()
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    key="$(cut -d" " -f1 <<<"$line")"
+    if [[ "$key" == dns-provider-* ]]; then
+      value="$(cut -d" " -f2- <<<"$line")"
+      global_values["$key"]="$value"
+      keyset["$key"]=1
+    fi
+  done < <(fn-plugin-property-get-all "letsencrypt" "--global")
+
+  if [[ "$APP" != "--global" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      key="$(cut -d" " -f1 <<<"$line")"
+      if [[ "$key" == dns-provider-* ]]; then
+        value="$(cut -d" " -f2- <<<"$line")"
+        app_values["$key"]="$value"
+        keyset["$key"]=1
+      fi
+    done < <(fn-plugin-property-get-all "letsencrypt" "$APP")
+  fi
+
+  [[ "${#keyset[@]}" -gt 0 ]] || return 0
+
+  local sorted_key app_value global_value computed_value
+  while IFS= read -r sorted_key; do
+    app_value="${app_values[$sorted_key]:-}"
+    global_value="${global_values[$sorted_key]:-}"
+    if [[ -n "$app_value" ]]; then
+      computed_value="$app_value"
+    else
+      computed_value="$global_value"
+    fi
+
+    if [[ "$sanitize" == "true" ]]; then
+      [[ -n "$app_value" ]] && app_value="****"
+      [[ -n "$global_value" ]] && global_value="****"
+      [[ -n "$computed_value" ]] && computed_value="****"
+    fi
+
+    if [[ -n "$computed_value" ]]; then
+      flag_map_ref+=("--letsencrypt-computed-${sorted_key}: ${computed_value}")
+    fi
+    if [[ -n "$global_value" ]]; then
+      flag_map_ref+=("--letsencrypt-global-${sorted_key}: ${global_value}")
+    fi
+    if [[ -n "$app_value" ]]; then
+      flag_map_ref+=("--letsencrypt-${sorted_key}: ${app_value}")
+    fi
+  done < <(printf '%s\n' "${!keyset[@]}" | sort)
+}

--- a/report
+++ b/report
@@ -3,4 +3,4 @@ source "$PLUGIN_AVAILABLE_PATH/letsencrypt/command-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
-cmd-letsencrypt-report-single "$@"
+LETSENCRYPT_REPORT_SANITIZE=true cmd-letsencrypt-report-single "$@"

--- a/tests/letsencrypt_report.bats
+++ b/tests/letsencrypt_report.bats
@@ -10,6 +10,9 @@ setup() {
 teardown() {
   cleanup_app "$APP"
   dokku letsencrypt:set --global graceperiod "" || true
+  dokku letsencrypt:set --global dns-provider-OVH_APPLICATION_KEY "" || true
+  dokku letsencrypt:set --global dns-provider-OVH_APPLICATION_SECRET "" || true
+  dokku letsencrypt:set --global dns-provider-NAMECHEAP_API_KEY "" || true
 }
 
 @test "letsencrypt:report renders a stdout report by default" {
@@ -67,4 +70,125 @@ teardown() {
   run dokku letsencrypt:report "$APP" --letsencrypt-graceperiod
   [ "$status" -eq 0 ]
   [ "$output" = "4242" ]
+}
+
+@test "letsencrypt:report includes an app-level dns-provider-* key in stdout" {
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku letsencrypt:report "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Letsencrypt dns provider OVH_APPLICATION_KEY"
+  echo "$output" | grep -q "app-secret"
+  ! echo "$output" | grep -q "Letsencrypt global dns provider OVH_APPLICATION_KEY"
+}
+
+@test "letsencrypt:report includes a global dns-provider-* key in stdout for an app" {
+  dokku letsencrypt:set --global dns-provider-NAMECHEAP_API_KEY global-secret
+
+  run dokku letsencrypt:report "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Letsencrypt global dns provider NAMECHEAP_API_KEY"
+  echo "$output" | grep -q "Letsencrypt computed dns provider NAMECHEAP_API_KEY"
+  echo "$output" | grep -q "global-secret"
+  ! echo "$output" | grep -qE "^[[:space:]]+Letsencrypt dns provider NAMECHEAP_API_KEY"
+}
+
+@test "letsencrypt:report --format json exposes dns-provider-* keys" {
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku letsencrypt:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+
+  value="$(echo "$output" | jq -r '."dns-provider-OVH_APPLICATION_KEY"')"
+  [ "$value" = "app-secret" ]
+
+  computed="$(echo "$output" | jq -r '."computed-dns-provider-OVH_APPLICATION_KEY"')"
+  [ "$computed" = "app-secret" ]
+
+  has_global="$(echo "$output" | jq -r 'has("global-dns-provider-OVH_APPLICATION_KEY")')"
+  [ "$has_global" = "false" ]
+}
+
+@test "letsencrypt:report info flag returns a dns-provider-* value" {
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-dns-provider-OVH_APPLICATION_KEY
+  [ "$status" -eq 0 ]
+  [ "$output" = "app-secret" ]
+}
+
+@test "letsencrypt:report computed dns-provider-* takes app value over global" {
+  dokku letsencrypt:set --global dns-provider-OVH_APPLICATION_KEY global-secret
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-computed-dns-provider-OVH_APPLICATION_KEY
+  [ "$status" -eq 0 ]
+  [ "$output" = "app-secret" ]
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-global-dns-provider-OVH_APPLICATION_KEY
+  [ "$status" -eq 0 ]
+  [ "$output" = "global-secret" ]
+}
+
+@test "letsencrypt:report --global includes global dns-provider-* keys" {
+  dokku letsencrypt:set --global dns-provider-NAMECHEAP_API_KEY global-secret
+
+  run dokku letsencrypt:report --global
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Letsencrypt global dns provider NAMECHEAP_API_KEY"
+  echo "$output" | grep -q "global-secret"
+}
+
+@test "letsencrypt:report --global --format json includes global-dns-provider-* and excludes non-global" {
+  dokku letsencrypt:set --global dns-provider-NAMECHEAP_API_KEY global-secret
+
+  run dokku letsencrypt:report --global --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+
+  value="$(echo "$output" | jq -r '."global-dns-provider-NAMECHEAP_API_KEY"')"
+  [ "$value" = "global-secret" ]
+
+  non_global="$(echo "$output" | jq -r 'keys[]' | grep -v '^global-' || true)"
+  [ -z "$non_global" ]
+}
+
+@test "dokku report redacts dns-provider-* credential values to ****" {
+  dokku letsencrypt:set "$APP" email "report@dokku.test"
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku report "$APP"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Letsencrypt dns provider OVH_APPLICATION_KEY"
+  echo "$output" | grep -q '\*\*\*\*'
+  ! echo "$output" | grep -q "app-secret"
+  echo "$output" | grep -q "report@dokku.test"
+}
+
+@test "dokku letsencrypt:report keeps dns-provider-* values raw after a dokku report run" {
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku report "$APP"
+  [ "$status" -eq 0 ]
+
+  run dokku letsencrypt:report "$APP" --letsencrypt-dns-provider-OVH_APPLICATION_KEY
+  [ "$status" -eq 0 ]
+  [ "$output" = "app-secret" ]
+}
+
+@test "dokku report leaves non-dns-provider-* fields unredacted" {
+  dokku letsencrypt:set "$APP" email "report@dokku.test"
+  dokku letsencrypt:set "$APP" dns-provider exec
+  dokku letsencrypt:set "$APP" dns-provider-OVH_APPLICATION_KEY app-secret
+
+  run dokku report "$APP"
+  [ "$status" -eq 0 ]
+  letsencrypt_section="$(echo "$output" | awk '/letsencrypt information/{flag=1} flag')"
+  echo "$letsencrypt_section" | grep -q "report@dokku.test"
+  echo "$letsencrypt_section" | grep -qE "Letsencrypt dns provider:[[:space:]]+exec"
+  echo "$letsencrypt_section" | grep -qE "Letsencrypt computed dns provider:[[:space:]]+exec"
+  echo "$letsencrypt_section" | grep -q "Letsencrypt dns provider OVH_APPLICATION_KEY"
+  echo "$letsencrypt_section" | grep -q '\*\*\*\*'
+  ! echo "$letsencrypt_section" | grep -q "app-secret"
 }


### PR DESCRIPTION
Dynamic `dns-provider-*` properties are read at report time and appended to `flag_map` alongside the static fields, so the values reach the report's stdout, JSON, info-flag, and `--global` forms. Each property emits the scopes that are actually set (`--letsencrypt-dns-provider-<KEY>` for app, `--letsencrypt-global-dns-provider-<KEY>` for global, plus a `--letsencrypt-computed-dns-provider-<KEY>` that resolves app over global). The top-level `dokku report` trigger sets `LETSENCRYPT_REPORT_SANITIZE=true` so the aggregate command redacts `dns-provider-*` credential values to `****` while leaving every other letsencrypt row (including the `dns-provider` name itself) unredacted; `dokku letsencrypt:report` still shows raw values for operator verification.

Fixes #304.