### PR TITLE
fix: preserve spaces in dns-provider-* values written to docker.env

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -501,7 +501,7 @@ fn-letsencrypt-configure-and-get-dir() {
       [[ -n "$line" ]] || continue
       key="$(cut -d" " -f1 <<<"$line")"
       if [[ "$key" == dns-provider-* ]]; then
-        value="$(cut -d" " -f2 <<<"$line")"
+        value="$(cut -d" " -f2- <<<"$line")"
         echo "${key#"dns-provider-"}=$value" >>"$config_dir/docker.env"
       fi
     done
@@ -509,7 +509,7 @@ fn-letsencrypt-configure-and-get-dir() {
       [[ -n "$line" ]] || continue
       key="$(cut -d" " -f1 <<<"$line")"
       if [[ "$key" == dns-provider-* ]]; then
-        value="$(cut -d" " -f2 <<<"$line")"
+        value="$(cut -d" " -f2- <<<"$line")"
         echo "${key#"dns-provider-"}=$value" >>"$config_dir/docker.env"
       fi
     done

--- a/tests/letsencrypt_enable_dns01.bats
+++ b/tests/letsencrypt_enable_dns01.bats
@@ -34,3 +34,14 @@ teardown() {
   $SUDO test -f "$current/docker.env"
   $SUDO grep -q '^EXEC_PATH=/usr/local/bin/challtestsrv-dns.sh$' "$current/docker.env"
 }
+
+@test "dns-provider-* values containing spaces are not truncated in docker.env" {
+  dokku letsencrypt:set --global dns-provider-EXEC_PROPAGATION_TIMEOUT "30 seconds with spaces"
+  dokku letsencrypt:enable "$APP"
+
+  current="$(current_config_dir "$APP")"
+  $SUDO test -f "$current/docker.env"
+  $SUDO grep -qx 'EXEC_PROPAGATION_TIMEOUT=30 seconds with spaces' "$current/docker.env"
+
+  dokku letsencrypt:set --global dns-provider-EXEC_PROPAGATION_TIMEOUT ""
+}


### PR DESCRIPTION
The previous parser used `cut -d" " -f2` when reading each `dns-provider-*` plugin property out of `fn-plugin-property-get-all`, which captured only the first space-delimited token of the stored value. Any provider env var whose value contained whitespace (e.g. a passphrase, a multi-word token) was silently truncated before lego ever saw it. Switching to `cut -d" " -f2-` preserves the full value through to the lego container's `docker.env`. Resolves #412.