### PR TITLE
refactor: house plugin-owned entries under --global subdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,6 @@ When the ACME server returns a rate-limit response, `letsencrypt:enable` exits n
 
 Let's Encrypt also limits new accounts per IP to 10 per 3 hours, which would be easy to trip on a busy dokku host. To stay clear of this, the plugin stores a single ACME account in `${DOKKU_LIB_ROOT}/data/letsencrypt/--global/accounts` and mounts it into every lego invocation. Apps sharing the same `email` and `server` reuse one account regardless of how many apps are enabled, matching Let's Encrypt's [recommendation](https://letsencrypt.org/docs/integration-guide/#one-account-or-many) for hosting providers. Apps configured with a distinct `email` or `server` get their own entry under the shared directory, keyed by `(server, email)`.
 
-Plugin-owned entries live under a `--global/` subdirectory rather than at the data-directory root, because per-app webroots are created as siblings of these entries and core dokku rejects any app name starting with `-`. The `install` and `update` hooks migrate the legacy `autorenew` cron marker into `--global/` on plugin upgrade.
-
 When upgrading from a previous version of this plugin, the first `letsencrypt:enable` after the upgrade registers exactly one new account in the shared directory. Existing per-app account material under `$DOKKU_ROOT/<app>/letsencrypt/certs/<hash>/accounts/` is left in place so that `letsencrypt:revoke` for certificates issued before the upgrade can still find the original account.
 
 ## App cloning and renaming

--- a/README.md
+++ b/README.md
@@ -378,10 +378,10 @@ dokku letsencrypt:set --global dns-provider-CLOUDFLARE_DNS_API_TOKEN_FILE /secre
 The lego [`exec` DNS provider](https://go-acme.github.io/lego/dns/exec/) shells out to a user-supplied script for creating and removing TXT records. The script must be reachable from inside the lego container at the path stored in `EXEC_PATH`. Use `lego-docker-options` to mount it from the host:
 
 ```shell
-sudo install -m 0755 /path/on/host/dns.sh /var/lib/dokku/data/letsencrypt/exec-dns.sh
+sudo install -m 0755 /path/on/host/dns.sh /var/lib/dokku/data/letsencrypt/--global/exec-dns.sh
 
 dokku letsencrypt:set --global dns-provider exec
-dokku letsencrypt:set --global lego-docker-options "-v /var/lib/dokku/data/letsencrypt/exec-dns.sh:/scripts/dns.sh:ro"
+dokku letsencrypt:set --global lego-docker-options "-v /var/lib/dokku/data/letsencrypt/--global/exec-dns.sh:/scripts/dns.sh:ro"
 dokku letsencrypt:set --global dns-provider-EXEC_PATH /scripts/dns.sh
 ```
 
@@ -467,7 +467,9 @@ When the ACME server returns a rate-limit response, `letsencrypt:enable` exits n
 
 ## Shared ACME account
 
-Let's Encrypt also limits new accounts per IP to 10 per 3 hours, which would be easy to trip on a busy dokku host. To stay clear of this, the plugin stores a single ACME account in `${DOKKU_LIB_ROOT}/data/letsencrypt/accounts` and mounts it into every lego invocation. Apps sharing the same `email` and `server` reuse one account regardless of how many apps are enabled, matching Let's Encrypt's [recommendation](https://letsencrypt.org/docs/integration-guide/#one-account-or-many) for hosting providers. Apps configured with a distinct `email` or `server` get their own entry under the shared directory, keyed by `(server, email)`.
+Let's Encrypt also limits new accounts per IP to 10 per 3 hours, which would be easy to trip on a busy dokku host. To stay clear of this, the plugin stores a single ACME account in `${DOKKU_LIB_ROOT}/data/letsencrypt/--global/accounts` and mounts it into every lego invocation. Apps sharing the same `email` and `server` reuse one account regardless of how many apps are enabled, matching Let's Encrypt's [recommendation](https://letsencrypt.org/docs/integration-guide/#one-account-or-many) for hosting providers. Apps configured with a distinct `email` or `server` get their own entry under the shared directory, keyed by `(server, email)`.
+
+Plugin-owned entries live under a `--global/` subdirectory rather than at the data-directory root, because per-app webroots are created as siblings of these entries and core dokku rejects any app name starting with `-`. The `install` and `update` hooks migrate the legacy `autorenew` cron marker into `--global/` on plugin upgrade.
 
 When upgrading from a previous version of this plugin, the first `letsencrypt:enable` after the upgrade registers exactly one new account in the shared directory. Existing per-app account material under `$DOKKU_ROOT/<app>/letsencrypt/certs/<hash>/accounts/` is left in place so that `letsencrypt:revoke` for certificates issued before the upgrade can still find the original account.
 

--- a/cron-entries
+++ b/cron-entries
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 trigger-letsencrypt-cron-entries() {
-  if [[ -f "${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew" ]]; then
+  if [[ -f "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/autorenew" ]]; then
     echo "24 6 * * *;dokku letsencrypt:auto-renew;/var/log/dokku/letsencrypt.log"
   fi
 }

--- a/install
+++ b/install
@@ -99,14 +99,23 @@ plugin-install() {
 
   mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt"
   chmod 0755 "${DOKKU_LIB_ROOT}/data/letsencrypt"
+  # Migrate the legacy autorenew marker into the --global container introduced
+  # to keep plugin-owned entries from colliding with same-named apps. Drop the
+  # legacy copy unconditionally once the new one exists.
+  mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/--global"
+  if [[ -f "${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew" && ! -e "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/autorenew" ]]; then
+    touch "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/autorenew"
+  fi
+  rm -f "${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew"
   # Heal per-app ACME webroots whose mode was previously left at the invoker's
   # umask (commonly 0700 under sudo). nginx must be able to read these to
   # serve HTTP-01 challenges; the files are public by design. Skip the
-  # dedicated `accounts/` dir, which is locked down to 0700 just below.
+  # `--global` container, whose `accounts/` leaf is locked down to 0700 just
+  # below.
   find "${DOKKU_LIB_ROOT}/data/letsencrypt" -mindepth 1 -maxdepth 1 -type d \
-    ! -name accounts -exec chmod 0755 {} +
-  mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
-  chmod 0700 "${DOKKU_LIB_ROOT}/data/letsencrypt/accounts"
+    ! -name '--global' -exec chmod 0755 {} +
+  mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/accounts"
+  chmod 0700 "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/accounts"
   chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/letsencrypt"
   fn-plugin-property-setup "letsencrypt"
   fn-letsencrypt-migrate-properties

--- a/internal-functions
+++ b/internal-functions
@@ -29,12 +29,12 @@ fn-letsencrypt-log-rate-limit() {
 
 fn-letsencrypt-shared-accounts-dir() {
   declare desc="dokku-host path to the shared lego accounts directory"
-  echo "$DOKKU_LIB_ROOT/data/letsencrypt/accounts"
+  echo "$DOKKU_LIB_ROOT/data/letsencrypt/--global/accounts"
 }
 
 fn-letsencrypt-shared-accounts-host-dir() {
   declare desc="docker-host path to the shared lego accounts directory"
-  echo "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/accounts"
+  echo "$DOKKU_LIB_HOST_ROOT/data/letsencrypt/--global/accounts"
 }
 
 fn-letsencrypt-ensure-shared-accounts-dir() {
@@ -538,7 +538,8 @@ fn-letsencrypt-cron-job-enabled() {
 fn-letsencrypt-cron-job-add() {
   declare desc="Add auto-renew cronjob to dokku user's crontab"
 
-  touch "${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew"
+  mkdir -p "${DOKKU_LIB_ROOT}/data/letsencrypt/--global"
+  touch "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/autorenew"
   if fn-letsencrypt-cron-job-enabled; then
     plugn trigger cron-write
   else
@@ -553,7 +554,7 @@ fn-letsencrypt-cron-job-add() {
 fn-letsencrypt-cron-job-remove() {
   declare desc="Remove auto-renew cronjob from dokku user's crontab"
 
-  rm -f "${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew"
+  rm -f "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/autorenew"
   if fn-letsencrypt-cron-job-enabled; then
     plugn trigger cron-write
   else
@@ -602,7 +603,7 @@ fn-letsencrypt-is-autorenew-enabled() {
   declare desc="check if autorenew is enabled"
   local enabled=false
 
-  if [[ -f "${DOKKU_LIB_ROOT}/data/letsencrypt/autorenew" ]]; then
+  if [[ -f "${DOKKU_LIB_ROOT}/data/letsencrypt/--global/autorenew" ]]; then
     enabled=true
   fi
 

--- a/tests/letsencrypt_cron_job.bats
+++ b/tests/letsencrypt_cron_job.bats
@@ -2,7 +2,7 @@
 
 load 'test_helper'
 
-AUTORENEW_FLAG="/var/lib/dokku/data/letsencrypt/autorenew"
+AUTORENEW_FLAG="/var/lib/dokku/data/letsencrypt/--global/autorenew"
 
 teardown() {
   dokku letsencrypt:cron-job --remove >/dev/null 2>&1 || true

--- a/tests/letsencrypt_install_perms.bats
+++ b/tests/letsencrypt_install_perms.bats
@@ -17,7 +17,7 @@ load 'test_helper'
 
   [ "$($SUDO stat -c '%a' "$parent")" = "755" ]
   [ "$($SUDO stat -c '%a' "$webroot")" = "755" ]
-  [ "$($SUDO stat -c '%a' "${parent}/accounts")" = "700" ]
+  [ "$($SUDO stat -c '%a' "${parent}/--global/accounts")" = "700" ]
 
   $SUDO rm -rf "$webroot"
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -129,7 +129,7 @@ config_hash_dirs() {
 }
 
 shared_accounts_dir() {
-  echo "/var/lib/dokku/data/letsencrypt/accounts"
+  echo "/var/lib/dokku/data/letsencrypt/--global/accounts"
 }
 
 # lego stores accounts under <accounts>/<host>/<email>/, with ':' in the host


### PR DESCRIPTION
Per-app webroots are created as siblings of `accounts/`, `autorenew`, and the documented `exec-dns.sh` example under `${DOKKU_LIB_ROOT}/data/letsencrypt/`, so an app named identically would collide. Core dokku rejects app names starting with `-`, so housing these entries under `--global/` makes the collision structurally impossible. The install/update hook migrates the legacy `autorenew` marker on plugin upgrade.