### PR TITLE
fix: bump plugin.toml version during release

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -42,11 +42,16 @@ jobs:
           bump: ${{ github.event.inputs.bump_type }}
           input: ${{ steps.latest-tag.outputs.GIT_LATEST_TAG }}
 
-      - name: Create and Push Tag
+      - name: Bump plugin.toml and Push Release
         run: |
           git config --global user.name 'Dokku Bot'
           git config --global user.email no-reply@dokku.com
+          VERSION="${GIT_NEXT_TAG#v}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" plugin.toml
+          git add plugin.toml
+          git commit -m "Release $VERSION"
           git tag "$GIT_NEXT_TAG"
+          git push origin "HEAD:$GITHUB_REF_NAME"
           git push origin "$GIT_NEXT_TAG"
         env:
           GIT_NEXT_TAG: ${{ steps.next-tag.outputs.version }}

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,5 +1,5 @@
 [plugin]
 description = "Automated installation of let's encrypt TLS certificates"
-version = "0.20.4"
+version = "0.25.0"
 sponsors = ["orca-scan"]
 [plugin.config]


### PR DESCRIPTION
Fixes #426.

The bump-version workflow computed the next semver tag and pushed it but never updated the version field in plugin.toml, so the plugin descriptor drifted behind the released git tags. The workflow now rewrites the plugin.toml version to the computed release version and commits it as Release X.Y.Z before tagging, pushing both the branch commit and the tag. The version is also realigned to the latest released tag to clear the existing drift. This mirrors the same fix already merged in dokku/dokku-maintenance.