### PR TITLE
fix: make letsencrypt work on a host with no apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ This is useful when copying certificates between servers (the new host has no AC
 
 ## Reports
 
-`letsencrypt:report` exposes per-app and global plugin properties for tooling and diagnostics. Without arguments it prints a human-readable report for every app, with an app name it reports on that app, and with `--global` it limits output to global properties.
+`letsencrypt:report` exposes per-app and global plugin properties for tooling and diagnostics. Without arguments it prints a human-readable report for every app, with an app name it reports on that app, and with `--global` it limits output to global properties. Because global properties are app-independent, `--global` works on a host that has no apps deployed yet, and an argument-less invocation on such a host warns instead of failing.
 
 ```shell
 dokku letsencrypt:report

--- a/command-functions
+++ b/command-functions
@@ -40,7 +40,7 @@ cmd-letsencrypt-auto-renew() {
     # if we should hit a rate limit along the way.
     # Store the list in a temporary file to avoid subshell issues with pipelines
     local temp_file=$(mktemp)
-    fn-letsencrypt-list-apps-with-expiry | sort -nk5 > "$temp_file"
+    fn-letsencrypt-list-apps-with-expiry --quiet | sort -nk5 > "$temp_file"
     
     while IFS=$'\t' read -r -a appExpiry; do
       if [[ ${appExpiry[4]} -lt 0 ]]; then

--- a/command-functions
+++ b/command-functions
@@ -225,8 +225,6 @@ cmd-letsencrypt-report() {
   set -- "${REPORT_ARGS[@]}"
 
   declare APP="${1:-}" INFO_FLAG="${2:-}"
-  local INSTALLED_APPS
-  INSTALLED_APPS=$(dokku_apps)
 
   if [[ -n "$APP" ]] && [[ "$APP" == --* ]]; then
     INFO_FLAG="$APP"
@@ -244,7 +242,7 @@ cmd-letsencrypt-report() {
   if [[ "$APP" == "--global" ]]; then
     cmd-letsencrypt-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
   elif [[ -z "$APP" ]]; then
-    for app in $INSTALLED_APPS; do
+    for app in $(dokku_apps); do
       cmd-letsencrypt-report-single "$app" "$INFO_FLAG" "$REPORT_FORMAT" | tee || true
     done
   else

--- a/internal-functions
+++ b/internal-functions
@@ -833,6 +833,7 @@ fn-letsencrypt-is-active() {
 
 fn-letsencrypt-list-apps-with-expiry() {
   declare desc="list all letsencrypt-secured apps together with their expiry date"
+  declare QUIET="${1:-}"
 
   # prints a tab-separated list of
   #  * app name
@@ -841,7 +842,20 @@ fn-letsencrypt-list-apps-with-expiry() {
   #  * time left on certificate (in seconds)
   #  * time until renewal (in seconds)
 
-  for APP in $(dokku_apps); do
+  # `dokku_apps` warns on stderr when the host has no apps. That is worth
+  # surfacing interactively, but not from the daily auto-renew cron job, where
+  # an app-less host is an unremarkable state rather than something to report.
+  # It reports the empty host by calling `dokku_log_fail`, which exits rather
+  # than returns, so the `|| true` has to sit outside the command substitution
+  # to keep `set -e` from aborting here.
+  local INSTALLED_APPS=""
+  if [[ "$QUIET" == "--quiet" ]]; then
+    INSTALLED_APPS="$(dokku_apps 2>/dev/null)" || true
+  else
+    INSTALLED_APPS="$(dokku_apps)" || true
+  fi
+
+  for APP in $INSTALLED_APPS; do
     if [[ "$APP" == "=====>" ]] || [[ "$APP" == "My" ]] || [[ "$APP" == "Apps" ]]; then continue; fi
     if [[ "$(fn-letsencrypt-is-active "$APP")" == "true" ]]; then
       local expiry=$(fn-letsencrypt-expiration "$APP")

--- a/tests/letsencrypt_no_apps.bats
+++ b/tests/letsencrypt_no_apps.bats
@@ -2,9 +2,9 @@
 
 load 'test_helper'
 
-# The global properties `letsencrypt:report` exposes are app-independent, so
-# reporting on them has to work on a host that has not deployed anything yet -
-# the state a provisioning tool sees right after `letsencrypt:set --global`.
+# A host that has not deployed anything yet is the state a provisioning tool
+# sees right after `letsencrypt:set --global`, and the state the auto-renew
+# cron job runs against every day. Neither should treat it as an error.
 
 setup() {
   destroy_all_apps
@@ -49,4 +49,17 @@ teardown() {
   run /bin/bash -c "dokku letsencrypt:report --format json 2>/dev/null"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+}
+
+@test "letsencrypt:auto-renew stays quiet about missing apps when the host has no apps" {
+  run dokku letsencrypt:auto-renew
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Finished auto-renewal"
+  ! echo "$output" | grep -q "You haven't deployed any applications yet"
+}
+
+@test "letsencrypt:list still reports that the host has no apps" {
+  run dokku letsencrypt:list
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "You haven't deployed any applications yet"
 }

--- a/tests/letsencrypt_report_no_apps.bats
+++ b/tests/letsencrypt_report_no_apps.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+# The global properties `letsencrypt:report` exposes are app-independent, so
+# reporting on them has to work on a host that has not deployed anything yet -
+# the state a provisioning tool sees right after `letsencrypt:set --global`.
+
+setup() {
+  destroy_all_apps
+}
+
+teardown() {
+  dokku letsencrypt:set --global graceperiod "" || true
+}
+
+@test "letsencrypt:report --global renders a report when the host has no apps" {
+  run dokku letsencrypt:report --global
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "global letsencrypt information"
+  echo "$output" | grep -q "Letsencrypt global email"
+}
+
+@test "letsencrypt:report --global --format json returns global keys when the host has no apps" {
+  dokku letsencrypt:set --global graceperiod 22222
+
+  run dokku letsencrypt:report --global --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  value="$(echo "$output" | jq -r '."global-graceperiod"')"
+  [ "$value" = "22222" ]
+}
+
+@test "letsencrypt:report --global info flag returns a value when the host has no apps" {
+  dokku letsencrypt:set --global graceperiod 33333
+
+  run dokku letsencrypt:report --global --letsencrypt-global-graceperiod
+  [ "$status" -eq 0 ]
+  [ "$output" = "33333" ]
+}
+
+@test "letsencrypt:report without an app warns instead of failing when the host has no apps" {
+  run dokku letsencrypt:report
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "You haven't deployed any applications yet"
+}
+
+@test "letsencrypt:report --format json emits nothing on stdout when the host has no apps" {
+  run /bin/bash -c "dokku letsencrypt:report --format json 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -27,6 +27,21 @@ cleanup_app() {
   fi
 }
 
+# `dokku apps:list` prints a `=====> My Apps` header before the app names and
+# warns on stderr when the host has no apps, so drop both.
+list_apps() {
+  dokku apps:list 2>/dev/null | grep -v '^=====>' || true
+}
+
+# Leaves the host with zero apps. Safe because bats runs the suite serially and
+# every other test file creates the app it needs in `setup`.
+destroy_all_apps() {
+  local app
+  for app in $(list_apps); do
+    cleanup_app "$app"
+  done
+}
+
 set_domain() {
   local app="$1" domain="$2"
   dokku domains:set "$app" "$domain"


### PR DESCRIPTION
The report command resolved the installed app list before deciding which branch to take, and that lookup aborts on a host with no apps, so `letsencrypt:report --global` failed even though every property it prints is app-independent. The list is now resolved only on the branch that iterates over apps, which also brings an argument-less invocation in line with `nginx:report`, where an app-less host produces a warning rather than a failure.

The daily auto-renew cron job hits the same lookup, and on a host with no apps it wrote `You haven't deployed any applications yet` into the letsencrypt log even though there was nothing to renew. That path now treats an app-less host as an empty list, while `letsencrypt:list` keeps reporting it so an interactive run still explains why the table is empty.

Fixes #433 
